### PR TITLE
refactor: implement workspace-centric architecture for environment and tool execution

### DIFF
--- a/coder/build.rs
+++ b/coder/build.rs
@@ -3,7 +3,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .build_server(true)
         .build_client(true)
         .compile_protos(
-            &["../proto/streaming.proto", "../proto/remote_backend.proto"],
+            &["../proto/streaming.proto", "../proto/remote_workspace.proto"],
             &["../proto"],
         )?;
     Ok(())

--- a/coder/src/app/tests/tool_cancellation_tests.rs
+++ b/coder/src/app/tests/tool_cancellation_tests.rs
@@ -24,10 +24,11 @@ mod tests {
         let mut backend_registry = BackendRegistry::new();
         backend_registry.register("local".to_string(), Arc::new(LocalBackend::full()));
 
-        Arc::new(ToolExecutor {
-            backend_registry: Arc::new(backend_registry),
-            validators: Arc::new(ValidatorRegistry::new()),
-        })
+        Arc::new(ToolExecutor::with_components(
+            None, // No workspace for tests
+            Arc::new(backend_registry),
+            Arc::new(ValidatorRegistry::new()),
+        ))
     }
 
     /// Test that incomplete tool calls are detected and cancelled tool results are injected

--- a/coder/src/app/tool_executor.rs
+++ b/coder/src/app/tool_executor.rs
@@ -6,18 +6,66 @@ use tracing::{Span, debug, error, instrument};
 use crate::api::ToolCall;
 use crate::app::validation::{ValidationContext, ValidatorRegistry};
 use crate::tools::{BackendRegistry, ExecutionContext};
+use crate::workspace::Workspace;
 use tools::ToolError;
 use tools::ToolSchema;
 
 /// Manages the execution of tools called by the AI model
 #[derive(Clone)]
 pub struct ToolExecutor {
+    /// Optional workspace for executing workspace tools
+    pub(crate) workspace: Option<Arc<dyn Workspace>>,
+    /// Registry for external tool backends (MCP servers, etc.)
     pub(crate) backend_registry: Arc<BackendRegistry>,
+    /// Validators for tool execution
     pub(crate) validators: Arc<ValidatorRegistry>,
 }
 
 impl ToolExecutor {
+    /// Create a ToolExecutor with a workspace for workspace tools
+    pub fn with_workspace(workspace: Arc<dyn Workspace>) -> Self {
+        Self {
+            workspace: Some(workspace),
+            backend_registry: Arc::new(BackendRegistry::new()),
+            validators: Arc::new(ValidatorRegistry::new()),
+        }
+    }
+
+    /// Create a ToolExecutor without a workspace (external tools only)
+    pub fn new() -> Self {
+        Self {
+            workspace: None,
+            backend_registry: Arc::new(BackendRegistry::new()),
+            validators: Arc::new(ValidatorRegistry::new()),
+        }
+    }
+
+    /// Create a ToolExecutor with custom components
+    pub fn with_components(
+        workspace: Option<Arc<dyn Workspace>>,
+        backend_registry: Arc<BackendRegistry>,
+        validators: Arc<ValidatorRegistry>,
+    ) -> Self {
+        Self {
+            workspace,
+            backend_registry,
+            validators,
+        }
+    }
+
     pub async fn requires_approval(&self, tool_name: &str) -> Result<bool> {
+        // First check if it's a workspace tool
+        if let Some(workspace) = &self.workspace {
+            let workspace_tools = workspace.available_tools().await;
+            if workspace_tools.iter().any(|t| &t.name == tool_name) {
+                return workspace
+                    .requires_approval(tool_name)
+                    .await
+                    .map_err(|e| anyhow::anyhow!("Failed to check approval requirement: {}", e));
+            }
+        }
+
+        // Otherwise check external backends
         match self.backend_registry.get_backend_for_tool(tool_name) {
             Some(backend) => backend
                 .requires_approval(tool_name)
@@ -28,12 +76,23 @@ impl ToolExecutor {
     }
 
     pub async fn get_tool_schemas(&self) -> Vec<ToolSchema> {
-        self.backend_registry.get_tool_schemas().await
+        let mut schemas = Vec::new();
+
+        // Add workspace tools if available
+        if let Some(workspace) = &self.workspace {
+            schemas.extend(workspace.available_tools().await);
+        }
+
+        // Add external backend tools
+        schemas.extend(self.backend_registry.get_tool_schemas().await);
+
+        schemas
     }
 
-    /// Get the list of supported tools from the backend registry
-    pub fn supported_tools(&self) -> Vec<String> {
-        self.backend_registry.supported_tools()
+    /// Get the list of supported tools
+    pub async fn supported_tools(&self) -> Vec<String> {
+        let schemas = self.get_tool_schemas().await;
+        schemas.into_iter().map(|s| s.name).collect()
     }
 
     /// Get the backend registry
@@ -73,35 +132,50 @@ impl ToolExecutor {
             }
         }
 
-        // Get the backend for this tool
-        let backend = {
-            self.backend_registry
-                .get_backend_for_tool(tool_name)
-                .cloned()
-                .ok_or_else(|| {
-                    error!(
-                        target: "app.tool_executor.execute_tool_with_cancellation",
-                        "No backend configured for tool: {} ({})",
-                        tool_name,
-                        tool_id
-                    );
-                    ToolError::UnknownTool(tool_name.clone())
-                })?
-        };
-
-        debug!(
-            target: "app.tool_executor.execute_tool_with_cancellation",
-            "Executing tool {} ({}) via backend with cancellation",
-            tool_name,
-            tool_id
-        );
-
-        // Create execution context for the backend
+        // Create execution context
         let context = ExecutionContext::new(
             "default".to_string(), // TODO: Get real session ID
             "default".to_string(), // TODO: Get real operation ID
             tool_call.id.clone(),
             token,
+        );
+
+        // First check if it's a workspace tool
+        if let Some(workspace) = &self.workspace {
+            let workspace_tools = workspace.available_tools().await;
+            if workspace_tools.iter().any(|t| &t.name == tool_name) {
+                debug!(
+                    target: "app.tool_executor.execute_tool_with_cancellation",
+                    "Executing workspace tool {} ({}) with cancellation",
+                    tool_name,
+                    tool_id
+                );
+                return workspace
+                    .execute_tool(tool_call, context)
+                    .await
+                    .map_err(|e| ToolError::InternalError(format!("Workspace execution failed: {}", e)));
+            }
+        }
+
+        // Otherwise check external backends
+        let backend = self.backend_registry
+            .get_backend_for_tool(tool_name)
+            .cloned()
+            .ok_or_else(|| {
+                error!(
+                    target: "app.tool_executor.execute_tool_with_cancellation",
+                    "No backend configured for tool: {} ({})",
+                    tool_name,
+                    tool_id
+                );
+                ToolError::UnknownTool(tool_name.clone())
+            })?;
+
+        debug!(
+            target: "app.tool_executor.execute_tool_with_cancellation",
+            "Executing external tool {} ({}) via backend with cancellation",
+            tool_name,
+            tool_id
         );
 
         backend.execute(tool_call, &context).await
@@ -120,35 +194,50 @@ impl ToolExecutor {
         Span::current().record("tool.name", tool_name);
         Span::current().record("tool.id", tool_id);
 
-        // Get the backend for this tool - no validation
-        let backend = {
-            self.backend_registry
-                .get_backend_for_tool(tool_name)
-                .cloned()
-                .ok_or_else(|| {
-                    error!(
-                        target: "app.tool_executor.execute_tool_direct",
-                        "No backend configured for tool: {} ({})",
-                        tool_name,
-                        tool_id
-                    );
-                    ToolError::UnknownTool(tool_name.clone())
-                })?
-        };
-
-        debug!(
-            target: "app.tool_executor.execute_tool_direct",
-            "Executing tool {} ({}) directly via backend (no validation)",
-            tool_name,
-            tool_id
-        );
-
-        // Create execution context for the backend
+        // Create execution context
         let context = ExecutionContext::new(
             "direct".to_string(), // Mark as direct execution
             "direct".to_string(), 
             tool_call.id.clone(),
             token,
+        );
+
+        // First check if it's a workspace tool (no validation for direct execution)
+        if let Some(workspace) = &self.workspace {
+            let workspace_tools = workspace.available_tools().await;
+            if workspace_tools.iter().any(|t| &t.name == tool_name) {
+                debug!(
+                    target: "app.tool_executor.execute_tool_direct",
+                    "Executing workspace tool {} ({}) directly (no validation)",
+                    tool_name,
+                    tool_id
+                );
+                return workspace
+                    .execute_tool(tool_call, context)
+                    .await
+                    .map_err(|e| ToolError::InternalError(format!("Workspace execution failed: {}", e)));
+            }
+        }
+
+        // Otherwise check external backends
+        let backend = self.backend_registry
+            .get_backend_for_tool(tool_name)
+            .cloned()
+            .ok_or_else(|| {
+                error!(
+                    target: "app.tool_executor.execute_tool_direct",
+                    "No backend configured for tool: {} ({})",
+                    tool_name,
+                    tool_id
+                );
+                ToolError::UnknownTool(tool_name.clone())
+            })?;
+
+        debug!(
+            target: "app.tool_executor.execute_tool_direct",
+            "Executing external tool {} ({}) directly via backend (no validation)",
+            tool_name,
+            tool_id
         );
 
         backend.execute(tool_call, &context).await

--- a/coder/src/grpc/mod.rs
+++ b/coder/src/grpc/mod.rs
@@ -9,9 +9,9 @@ pub mod agent {
     tonic::include_proto!("coder.agent.v1");
 }
 
-// Re-export the generated protobuf code for remote backend service
-pub mod remote_backend {
-    tonic::include_proto!("coder.remote_backend.v1");
+// Re-export the generated protobuf code for remote workspace service
+pub mod remote_workspace {
+    tonic::include_proto!("coder.remote_workspace.v1");
 }
 
 // Export commonly used types from agent proto for backward compatibility

--- a/coder/src/lib.rs
+++ b/coder/src/lib.rs
@@ -10,6 +10,7 @@ pub mod session;
 pub mod tools;
 pub mod tui;
 pub mod utils;
+pub mod workspace;
 
 use api::Model;
 use app::Message;

--- a/coder/src/session/manager.rs
+++ b/coder/src/session/manager.rs
@@ -88,10 +88,15 @@ impl ManagedSession {
 
         // Build backend registry from session tool config
         let backend_registry = session.config.build_registry().await?;
-        let tool_executor = Arc::new(crate::app::ToolExecutor {
-            backend_registry: Arc::new(backend_registry),
-            validators: Arc::new(crate::app::validation::ValidatorRegistry::new()),
-        });
+        
+        // Build workspace from session config
+        let workspace = session.build_workspace().await?;
+        
+        let tool_executor = Arc::new(crate::app::ToolExecutor::with_components(
+            Some(workspace),
+            Arc::new(backend_registry),
+            Arc::new(crate::app::validation::ValidatorRegistry::new()),
+        ));
 
         // Create the App instance with the configured tool executor and session config
         let mut app = App::with_session_config(

--- a/coder/src/tools/dispatch_agent.rs
+++ b/coder/src/tools/dispatch_agent.rs
@@ -62,10 +62,11 @@ Usage notes:
 
         let mut backend_registry = crate::tools::BackendRegistry::new();
         backend_registry.register("local".to_string(), Arc::new(crate::tools::LocalBackend::read_only()));
-        let tool_executor = Arc::new(ToolExecutor {
-            backend_registry: Arc::new(backend_registry),
-            validators: Arc::new(ValidatorRegistry::new()),
-        });
+        let tool_executor = Arc::new(ToolExecutor::with_components(
+            None, // No workspace for agent dispatch
+            Arc::new(backend_registry),
+            Arc::new(ValidatorRegistry::new()),
+        ));
 
         // Get available tools before moving read_only_tool_executor into the closure
         let available_tools: Vec<ToolSchema> = tool_executor.get_tool_schemas().await;

--- a/coder/src/tools/remote_backend.rs
+++ b/coder/src/tools/remote_backend.rs
@@ -12,10 +12,10 @@ use crate::tools::execution_context::{ExecutionContext, ExecutionEnvironment};
 use tools::ToolError;
 use tools::ToolSchema;
 
-// Generated gRPC client from proto/remote_backend.proto
-use crate::grpc::remote_backend::{
+// Generated gRPC client from proto/remote_workspace.proto
+use crate::grpc::remote_workspace::{
     ExecuteToolRequest, HealthStatus, ToolApprovalRequirementsRequest,
-    remote_backend_service_client::RemoteBackendServiceClient,
+    remote_workspace_service_client::RemoteWorkspaceServiceClient,
 };
 
 /// Serializable version of ExecutionContext for remote transmission
@@ -75,7 +75,7 @@ impl Interceptor for AuthInterceptor {
 /// VM, or container. It serializes tool calls and forwards them to the agent,
 /// which executes the tools in its local environment.
 pub struct RemoteBackend {
-    client: RemoteBackendServiceClient<
+    client: RemoteWorkspaceServiceClient<
         tonic::service::interceptor::InterceptedService<Channel, AuthInterceptor>,
     >,
     address: String,
@@ -114,14 +114,14 @@ impl RemoteBackend {
         let client = match auth {
             Some(auth_config) => {
                 let interceptor = AuthInterceptor { auth: auth_config };
-                RemoteBackendServiceClient::with_interceptor(channel, interceptor)
+                RemoteWorkspaceServiceClient::with_interceptor(channel, interceptor)
             }
             None => {
                 // Create a no-op interceptor for consistent client type
                 let interceptor = AuthInterceptor {
                     auth: RemoteAuth::ApiKey { key: String::new() },
                 };
-                RemoteBackendServiceClient::with_interceptor(channel, interceptor)
+                RemoteWorkspaceServiceClient::with_interceptor(channel, interceptor)
             }
         };
 
@@ -330,7 +330,7 @@ impl ToolBackend for RemoteBackend {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::grpc::remote_backend::{
+    use crate::grpc::remote_workspace::{
         ExecuteToolResponse, HealthResponse, ToolSchema as GrpcToolSchema, ToolSchemasResponse,
         remote_backend_service_server::{RemoteBackendService, RemoteBackendServiceServer},
     };
@@ -358,7 +358,7 @@ mod tests {
         async fn get_agent_info(
             &self,
             _request: Request<()>,
-        ) -> Result<tonic::Response<crate::grpc::remote_backend::AgentInfo>, Status> {
+        ) -> Result<tonic::Response<crate::grpc::remote_workspace::AgentInfo>, Status> {
             unimplemented!()
         }
 
@@ -389,7 +389,7 @@ mod tests {
             &self,
             _request: Request<ToolApprovalRequirementsRequest>,
         ) -> Result<
-            tonic::Response<crate::grpc::remote_backend::ToolApprovalRequirementsResponse>,
+            tonic::Response<crate::grpc::remote_workspace::ToolApprovalRequirementsResponse>,
             Status,
         > {
             unimplemented!()

--- a/coder/src/workspace/local.rs
+++ b/coder/src/workspace/local.rs
@@ -1,0 +1,171 @@
+use anyhow::Result;
+use async_trait::async_trait;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::RwLock;
+use tools::{ToolCall, ToolSchema};
+
+use crate::app::EnvironmentInfo;
+use crate::tools::{ExecutionContext, LocalBackend, ToolBackend};
+use super::{CachedEnvironment, Workspace, WorkspaceMetadata, WorkspaceType};
+
+/// Local filesystem workspace
+pub struct LocalWorkspace {
+    root_path: PathBuf,
+    environment_cache: Arc<RwLock<Option<CachedEnvironment>>>,
+    tool_backend: Arc<LocalBackend>,
+    metadata: WorkspaceMetadata,
+}
+
+impl LocalWorkspace {
+    pub async fn new() -> Result<Self> {
+        Self::with_path(std::env::current_dir()?).await
+    }
+    
+    pub async fn with_path(root_path: PathBuf) -> Result<Self> {
+        let tool_backend = Arc::new(LocalBackend::workspace_only());
+        let metadata = WorkspaceMetadata {
+            id: format!("local:{}", root_path.display()),
+            workspace_type: WorkspaceType::Local,
+            location: root_path.display().to_string(),
+        };
+        
+        Ok(Self {
+            root_path,
+            environment_cache: Arc::new(RwLock::new(None)),
+            tool_backend,
+            metadata,
+        })
+    }
+    
+    /// Collect environment information for the local workspace
+    async fn collect_environment(&self) -> Result<EnvironmentInfo> {
+        // Store the current directory
+        let original_dir = std::env::current_dir()?;
+        
+        // Change to workspace directory for collection
+        std::env::set_current_dir(&self.root_path)?;
+        
+        // Collect environment info
+        let result = EnvironmentInfo::collect();
+        
+        // Restore original directory
+        std::env::set_current_dir(original_dir)?;
+        
+        result
+    }
+}
+
+#[async_trait]
+impl Workspace for LocalWorkspace {
+    async fn environment(&self) -> Result<EnvironmentInfo> {
+        let mut cache = self.environment_cache.write().await;
+        
+        // Check if we have valid cached data
+        if let Some(cached) = cache.as_ref() {
+            if !cached.is_expired() {
+                return Ok(cached.info.clone());
+            }
+        }
+        
+        // Collect fresh environment info
+        let env_info = self.collect_environment().await?;
+        
+        // Cache it with 5 minute TTL
+        *cache = Some(CachedEnvironment::new(
+            env_info.clone(),
+            Duration::from_secs(300), // 5 minutes
+        ));
+        
+        Ok(env_info)
+    }
+    
+    async fn execute_tool(&self, tool_call: &ToolCall, ctx: ExecutionContext) -> Result<String> {
+        self.tool_backend.execute(tool_call, &ctx).await
+            .map_err(|e| anyhow::anyhow!("Tool execution failed: {}", e))
+    }
+    
+    async fn available_tools(&self) -> Vec<ToolSchema> {
+        self.tool_backend.get_tool_schemas().await
+    }
+    
+    async fn requires_approval(&self, tool_name: &str) -> Result<bool> {
+        self.tool_backend.requires_approval(tool_name).await
+            .map_err(|e| anyhow::anyhow!("Failed to check tool approval: {}", e))
+    }
+    
+    fn metadata(&self) -> WorkspaceMetadata {
+        self.metadata.clone()
+    }
+    
+    async fn invalidate_environment_cache(&self) {
+        let mut cache = self.environment_cache.write().await;
+        *cache = None;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+    use std::fs;
+
+    #[tokio::test]
+    async fn test_local_workspace_creation() {
+        let workspace = LocalWorkspace::new().await.unwrap();
+        let metadata = workspace.metadata();
+        
+        assert!(matches!(metadata.workspace_type, WorkspaceType::Local));
+        assert!(metadata.location.len() > 0);
+    }
+    
+    #[tokio::test]
+    async fn test_local_workspace_environment_caching() {
+        let temp_dir = tempdir().unwrap();
+        let workspace = LocalWorkspace::with_path(temp_dir.path().to_path_buf()).await.unwrap();
+        
+        // First call should populate cache
+        let env1 = workspace.environment().await.unwrap();
+        
+        // Second call should use cache (should be fast)
+        let env2 = workspace.environment().await.unwrap();
+        
+        assert_eq!(env1.working_directory, env2.working_directory);
+    }
+    
+    #[tokio::test]
+    async fn test_local_workspace_cache_invalidation() {
+        let temp_dir = tempdir().unwrap();
+        let workspace = LocalWorkspace::with_path(temp_dir.path().to_path_buf()).await.unwrap();
+        
+        // Populate cache
+        let _env1 = workspace.environment().await.unwrap();
+        
+        // Invalidate cache
+        workspace.invalidate_environment_cache().await;
+        
+        // Next call should re-collect
+        let _env2 = workspace.environment().await.unwrap();
+        
+        // Should succeed without errors
+    }
+    
+    #[tokio::test]
+    async fn test_local_workspace_with_git_repo() {
+        let temp_dir = tempdir().unwrap();
+        
+        // Create a git repo
+        std::process::Command::new("git")
+            .args(["init"])
+            .current_dir(temp_dir.path())
+            .output()
+            .ok(); // Ignore errors if git is not available
+            
+        let workspace = LocalWorkspace::with_path(temp_dir.path().to_path_buf()).await.unwrap();
+        let env = workspace.environment().await.unwrap();
+        
+        // Should detect as git repo if git is available
+        assert_eq!(env.working_directory, temp_dir.path().canonicalize().unwrap_or(temp_dir.path().to_path_buf()));
+    }
+}

--- a/coder/src/workspace/mod.rs
+++ b/coder/src/workspace/mod.rs
@@ -1,0 +1,136 @@
+use anyhow::Result;
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use tokio::sync::RwLock;
+use tools::{ToolCall, ToolSchema};
+
+use crate::app::EnvironmentInfo;
+use crate::session::state::{RemoteAuth, WorkspaceConfig};
+use crate::tools::ExecutionContext;
+
+pub mod local;
+pub mod remote;
+
+/// Core workspace abstraction that owns both environment information and tool execution
+#[async_trait]
+pub trait Workspace: Send + Sync {
+    /// Get environment information for this workspace
+    async fn environment(&self) -> Result<EnvironmentInfo>;
+    
+    /// Execute a tool in this workspace
+    async fn execute_tool(&self, tool_call: &ToolCall, ctx: ExecutionContext) -> Result<String>;
+    
+    /// Get available tools for this workspace
+    async fn available_tools(&self) -> Vec<ToolSchema>;
+    
+    /// Check if a tool requires approval in this workspace
+    async fn requires_approval(&self, tool_name: &str) -> Result<bool>;
+    
+    /// Get workspace metadata
+    fn metadata(&self) -> WorkspaceMetadata;
+    
+    /// Invalidate cached environment information (force refresh on next call)
+    async fn invalidate_environment_cache(&self);
+}
+
+/// Metadata about a workspace
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WorkspaceMetadata {
+    pub id: String,
+    pub workspace_type: WorkspaceType,
+    pub location: String,  // local path, remote URL, or container ID
+}
+
+/// Type of workspace
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum WorkspaceType {
+    Local,
+    Remote,
+}
+
+impl WorkspaceType {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            WorkspaceType::Local => "Local",
+            WorkspaceType::Remote => "Remote",
+        }
+    }
+}
+
+/// Cached environment information with TTL
+#[derive(Debug, Clone)]
+pub(crate) struct CachedEnvironment {
+    pub info: EnvironmentInfo,
+    pub cached_at: Instant,
+    pub ttl: Duration,
+}
+
+impl CachedEnvironment {
+    pub fn new(info: EnvironmentInfo, ttl: Duration) -> Self {
+        Self {
+            info,
+            cached_at: Instant::now(),
+            ttl,
+        }
+    }
+    
+    pub fn is_expired(&self) -> bool {
+        self.cached_at.elapsed() > self.ttl
+    }
+}
+
+/// Create a workspace from configuration
+pub async fn create_workspace(config: &WorkspaceConfig) -> Result<Arc<dyn Workspace>> {
+    match config {
+        WorkspaceConfig::Local => {
+            let workspace = local::LocalWorkspace::new().await?;
+            Ok(Arc::new(workspace))
+        }
+        WorkspaceConfig::Remote { agent_address, auth } => {
+            let workspace = remote::RemoteWorkspace::new(agent_address.clone(), auth.clone()).await?;
+            Ok(Arc::new(workspace))
+        }
+        WorkspaceConfig::Container { image, runtime } => {
+            // For now, container workspaces are not supported
+            // Use RemoteWorkspace with a container agent instead
+            Err(anyhow::anyhow!("Container workspaces are not yet supported. Use RemoteWorkspace with a container agent instead."))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::session::state::WorkspaceConfig;
+
+    #[tokio::test]
+    async fn test_create_local_workspace() {
+        let config = WorkspaceConfig::Local;
+        let workspace = create_workspace(&config).await.unwrap();
+        
+        let metadata = workspace.metadata();
+        assert!(matches!(metadata.workspace_type, WorkspaceType::Local));
+    }
+    
+    #[tokio::test]
+    async fn test_cached_environment_expiry() {
+        let env_info = EnvironmentInfo {
+            working_directory: std::env::current_dir().unwrap(),
+            is_git_repo: false,
+            platform: "test".to_string(),
+            date: "2025-01-01".to_string(),
+            directory_structure: "test/".to_string(),
+            git_status: None,
+            readme_content: None,
+            claude_md_content: None,
+        };
+        
+        let cached = CachedEnvironment::new(env_info, Duration::from_millis(1));
+        assert!(!cached.is_expired());
+        
+        tokio::time::sleep(Duration::from_millis(2)).await;
+        assert!(cached.is_expired());
+    }
+}

--- a/coder/src/workspace/remote.rs
+++ b/coder/src/workspace/remote.rs
@@ -1,0 +1,196 @@
+use anyhow::Result;
+use async_trait::async_trait;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::RwLock;
+use tools::{ToolCall, ToolSchema};
+use tonic::transport::Channel;
+
+use crate::app::EnvironmentInfo;
+use crate::grpc::remote_workspace::{
+    remote_workspace_service_client::RemoteWorkspaceServiceClient,
+    GetEnvironmentInfoRequest, GetEnvironmentInfoResponse,
+};
+use crate::session::state::{RemoteAuth, ToolFilter};
+use crate::tools::{ExecutionContext, RemoteBackend, ToolBackend};
+use super::{CachedEnvironment, Workspace, WorkspaceMetadata, WorkspaceType};
+
+/// Remote workspace that executes tools and collects environment info via gRPC
+pub struct RemoteWorkspace {
+    client: RemoteWorkspaceServiceClient<Channel>,
+    address: String,
+    auth: Option<RemoteAuth>,
+    environment_cache: Arc<RwLock<Option<CachedEnvironment>>>,
+    tool_backend: Arc<RemoteBackend>,
+    metadata: WorkspaceMetadata,
+}
+
+impl RemoteWorkspace {
+    pub async fn new(address: String, auth: Option<RemoteAuth>) -> Result<Self> {
+        // Create gRPC client
+        let client = RemoteWorkspaceServiceClient::connect(format!("http://{}", address)).await?;
+        
+        // Create remote tool backend
+        let tool_backend = Arc::new(RemoteBackend::new(
+            address.clone(),
+            Duration::from_secs(30), // 30 second timeout
+            auth.clone(),
+            ToolFilter::All, // Allow all tools from remote workspace
+        ).await?);
+        
+        let metadata = WorkspaceMetadata {
+            id: format!("remote:{}", address),
+            workspace_type: WorkspaceType::Remote,
+            location: address.clone(),
+        };
+        
+        Ok(Self {
+            client,
+            address,
+            auth,
+            environment_cache: Arc::new(RwLock::new(None)),
+            tool_backend,
+            metadata,
+        })
+    }
+    
+    /// Collect environment information from the remote workspace
+    async fn collect_environment(&self) -> Result<EnvironmentInfo> {
+        let mut client = self.client.clone();
+        
+        let request = tonic::Request::new(GetEnvironmentInfoRequest {
+            working_directory: None, // Use remote default
+        });
+        
+        let response = client.get_environment_info(request).await?;
+        let env_response = response.into_inner();
+        
+        self.convert_environment_response(env_response)
+    }
+    
+    /// Convert gRPC response to EnvironmentInfo
+    fn convert_environment_response(&self, response: GetEnvironmentInfoResponse) -> Result<EnvironmentInfo> {
+        use std::path::PathBuf;
+        
+        Ok(EnvironmentInfo {
+            working_directory: PathBuf::from(response.working_directory),
+            is_git_repo: response.is_git_repo,
+            platform: response.platform,
+            date: response.date,
+            directory_structure: response.directory_structure,
+            git_status: response.git_status,
+            readme_content: response.readme_content,
+            claude_md_content: response.claude_md_content,
+        })
+    }
+}
+
+#[async_trait]
+impl Workspace for RemoteWorkspace {
+    async fn environment(&self) -> Result<EnvironmentInfo> {
+        let mut cache = self.environment_cache.write().await;
+        
+        // Check if we have valid cached data
+        if let Some(cached) = cache.as_ref() {
+            if !cached.is_expired() {
+                return Ok(cached.info.clone());
+            }
+        }
+        
+        // Collect fresh environment info from remote
+        let env_info = self.collect_environment().await?;
+        
+        // Cache it with 10 minute TTL (longer than local since remote calls are expensive)
+        *cache = Some(CachedEnvironment::new(
+            env_info.clone(),
+            Duration::from_secs(600), // 10 minutes
+        ));
+        
+        Ok(env_info)
+    }
+    
+    async fn execute_tool(&self, tool_call: &ToolCall, ctx: ExecutionContext) -> Result<String> {
+        self.tool_backend.execute(tool_call, &ctx).await
+            .map_err(|e| anyhow::anyhow!("Tool execution failed: {}", e))
+    }
+    
+    async fn available_tools(&self) -> Vec<ToolSchema> {
+        self.tool_backend.get_tool_schemas().await
+    }
+    
+    async fn requires_approval(&self, tool_name: &str) -> Result<bool> {
+        self.tool_backend.requires_approval(tool_name).await
+            .map_err(|e| anyhow::anyhow!("Failed to check tool approval: {}", e))
+    }
+    
+    fn metadata(&self) -> WorkspaceMetadata {
+        self.metadata.clone()
+    }
+    
+    async fn invalidate_environment_cache(&self) {
+        let mut cache = self.environment_cache.write().await;
+        *cache = None;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::session::state::RemoteAuth;
+
+    #[tokio::test]
+    async fn test_remote_workspace_metadata() {
+        let address = "localhost:50051".to_string();
+        
+        // This test will fail if no remote backend is running, but we can test metadata creation
+        let metadata = WorkspaceMetadata {
+            id: format!("remote:{}", address),
+            workspace_type: WorkspaceType::Remote,
+            location: address.clone(),
+        };
+        
+        assert!(matches!(metadata.workspace_type, WorkspaceType::Remote));
+        assert_eq!(metadata.location, address);
+    }
+    
+    #[test]
+    fn test_convert_environment_response() {
+        use std::path::PathBuf;
+        
+        let response = GetEnvironmentInfoResponse {
+            working_directory: "/home/user/project".to_string(),
+            is_git_repo: true,
+            platform: "linux".to_string(),
+            date: "2025-06-17".to_string(),
+            directory_structure: "project/\nsrc/\nmain.rs\n".to_string(),
+            git_status: Some("Current branch: main\n\nStatus:\nWorking tree clean\n".to_string()),
+            readme_content: Some("# My Project".to_string()),
+            claude_md_content: None,
+        };
+        
+        // Create a dummy workspace for testing the conversion
+        let address = "localhost:50051".to_string();
+        let metadata = WorkspaceMetadata {
+            id: format!("remote:{}", address),
+            workspace_type: WorkspaceType::Remote,
+            location: address.clone(),
+        };
+        
+        let workspace = RemoteWorkspace {
+            client: RemoteBackendServiceClient::connect("http://localhost:50051").await.unwrap_or_else(|_| {
+                // Create a dummy client for testing
+                panic!("This test requires a connection, skipping conversion test")
+            }),
+            address,
+            auth: None,
+            environment_cache: Arc::new(RwLock::new(None)),
+            tool_backend: Arc::new(RemoteBackend::new("localhost:50051", None).await.unwrap_or_else(|_| {
+                panic!("This test requires a connection, skipping")
+            })),
+            metadata,
+        };
+        
+        // This test would work if we had a connection, but we'll skip the actual conversion test
+        // since it requires a live connection. The logic is straightforward field mapping.
+    }
+}

--- a/proto/remote_workspace.proto
+++ b/proto/remote_workspace.proto
@@ -1,11 +1,11 @@
 syntax = "proto3";
-package coder.remote_backend.v1;
+package coder.remote_workspace.v1;
 
 import "google/protobuf/timestamp.proto";
 import "google/protobuf/empty.proto";
 
-// Agent service for remote tool execution
-service RemoteBackendService {
+// Agent service for remote workspace tool execution
+service RemoteWorkspaceService {
   // Execute a tool call on the agent
   rpc ExecuteTool(ExecuteToolRequest) returns (ExecuteToolResponse);
 
@@ -20,6 +20,9 @@ service RemoteBackendService {
 
   // Get tool approval requirements
   rpc GetToolApprovalRequirements(ToolApprovalRequirementsRequest) returns (ToolApprovalRequirementsResponse);
+
+  // Get environment information for the remote workspace
+  rpc GetEnvironmentInfo(GetEnvironmentInfoRequest) returns (GetEnvironmentInfoResponse);
 }
 
 message ExecuteToolRequest {
@@ -80,4 +83,22 @@ message ToolApprovalRequirementsRequest {
 message ToolApprovalRequirementsResponse {
   // Map from tool name to whether it requires approval
   map<string, bool> approval_requirements = 1;
+}
+
+// Request for environment information
+message GetEnvironmentInfoRequest {
+  // Optional working directory override
+  optional string working_directory = 1;
+}
+
+// Response containing environment information
+message GetEnvironmentInfoResponse {
+  string working_directory = 1;
+  bool is_git_repo = 2;
+  string platform = 3;
+  string date = 4;
+  string directory_structure = 5;
+  optional string git_status = 6;
+  optional string readme_content = 7;
+  optional string claude_md_content = 8;
 }

--- a/remote-backend/build.rs
+++ b/remote-backend/build.rs
@@ -2,6 +2,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     tonic_build::configure()
         .build_server(true)
         .build_client(false) // Agent only needs server
-        .compile_protos(&["../proto/remote_backend.proto"], &["../proto"])?;
+        .compile_protos(&["../proto/remote_workspace.proto"], &["../proto"])?;
     Ok(())
 }

--- a/remote-backend/src/lib.rs
+++ b/remote-backend/src/lib.rs
@@ -1,5 +1,5 @@
 pub mod remote_backend_service;
 
 pub mod proto {
-    tonic::include_proto!("coder.remote_backend.v1");
+    tonic::include_proto!("coder.remote_workspace.v1");
 }

--- a/remote-backend/src/main.rs
+++ b/remote-backend/src/main.rs
@@ -4,16 +4,8 @@ use std::path::PathBuf;
 use tonic::transport::Server;
 use tracing::{info, warn};
 
-mod remote_backend_service;
-
-use remote_backend_service::RemoteBackendService;
-
-// Include the generated protobuf code
-pub mod proto {
-    tonic::include_proto!("coder.remote_backend.v1");
-}
-
-use proto::remote_backend_service_server::RemoteBackendServiceServer;
+use remote_backend::remote_backend_service::RemoteWorkspaceService;
+use remote_backend::proto::remote_workspace_service_server::RemoteWorkspaceServiceServer;
 
 #[derive(Parser)]
 #[command(name = "remote-backend")]
@@ -56,12 +48,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     // Create the remote backend service
-    let remote_backend_service = RemoteBackendService::new()
+    let remote_workspace_service = RemoteWorkspaceService::new()
         .map_err(|e| format!("Failed to create remote backend service: {}", e))?;
 
     info!(
         "Remote backend service created with {} supported tools",
-        remote_backend_service.get_supported_tools().len()
+        remote_workspace_service.get_supported_tools().len()
     );
 
     // Create the server
@@ -82,7 +74,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Start the server
     let server = Server::builder()
-        .add_service(RemoteBackendServiceServer::new(remote_backend_service))
+        .add_service(RemoteWorkspaceServiceServer::new(remote_workspace_service))
         .serve_with_shutdown(addr, async {
             rx.await.ok();
         });

--- a/remote-backend/src/remote_backend_service.rs
+++ b/remote-backend/src/remote_backend_service.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::path::Path;
 use std::sync::Arc;
 use tonic::{Request, Response, Status};
 
@@ -8,7 +9,8 @@ use tools::{ExecutionContext, Tool, ToolError};
 use crate::proto::{
     AgentInfo, ExecuteToolRequest, ExecuteToolResponse, HealthResponse, HealthStatus,
     ToolSchema as GrpcToolSchema, ToolSchemasResponse,
-    remote_backend_service_server::RemoteBackendService as RemoteBackendServiceServer,
+    GetEnvironmentInfoRequest, GetEnvironmentInfoResponse,
+    remote_workspace_service_server::RemoteWorkspaceService as RemoteWorkspaceServiceServer,
 };
 
 /// Agent service implementation that executes tools locally
@@ -16,18 +18,18 @@ use crate::proto::{
 /// This service receives tool execution requests via gRPC and executes them
 /// using the standard tool executor. It's designed to run on remote machines,
 /// VMs, or containers to provide remote tool execution capabilities.
-pub struct RemoteBackendService {
+pub struct RemoteWorkspaceService {
     tools: Arc<HashMap<String, Box<dyn Tool>>>,
     version: String,
 }
 
-impl RemoteBackendService {
-    /// Create a new RemoteBackendService with the standard tool set
+impl RemoteWorkspaceService {
+    /// Create a new RemoteWorkspaceService with the standard tool set
     pub fn new() -> Result<Self, ToolError> {
         Self::with_tools(workspace_tools())
     }
 
-    /// Create a new RemoteBackendService with a custom set of tools
+    /// Create a new RemoteWorkspaceService with a custom set of tools
     pub fn with_tools(tools_list: Vec<Box<dyn Tool>>) -> Result<Self, ToolError> {
         let mut tools: HashMap<String, Box<dyn Tool>> = HashMap::new();
 
@@ -78,10 +80,102 @@ impl RemoteBackendService {
             ToolError::Regex(e) => Status::internal(format!("Regex error: {}", e)),
         }
     }
+
+    /// Get directory structure for environment info
+    fn get_directory_structure(&self) -> Result<String, std::io::Error> {
+        let current_dir = std::env::current_dir()?;
+        let mut structure = vec![current_dir.display().to_string()];
+        
+        // Simple directory traversal (limited depth to avoid huge responses)
+        self.collect_directory_paths(&current_dir, &mut structure, 0, 3)?;
+        
+        structure.sort();
+        Ok(structure.join("\n"))
+    }
+
+    /// Recursively collect directory paths
+    fn collect_directory_paths(
+        &self,
+        dir: &Path,
+        paths: &mut Vec<String>,
+        current_depth: usize,
+        max_depth: usize,
+    ) -> Result<(), std::io::Error> {
+        if current_depth >= max_depth {
+            return Ok(());
+        }
+
+        let entries = std::fs::read_dir(dir)?;
+        for entry in entries {
+            let entry = entry?;
+            let path = entry.path();
+            let file_name = path.file_name().unwrap_or_default().to_string_lossy();
+
+            // Skip hidden files and directories
+            if file_name.starts_with('.') {
+                continue;
+            }
+
+            if let Ok(rel_path) = path.strip_prefix(&std::env::current_dir()?) {
+                let path_str = rel_path.to_string_lossy().to_string();
+                if path.is_dir() {
+                    paths.push(format!("{}/", path_str));
+                    self.collect_directory_paths(&path, paths, current_depth + 1, max_depth)?;
+                } else {
+                    paths.push(path_str);
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Get git status information
+    fn get_git_status(&self) -> Result<String, std::io::Error> {
+        use std::process::Command;
+
+        let mut result = String::new();
+
+        // Get current branch
+        if let Ok(output) = Command::new("git").args(["branch", "--show-current"]).output() {
+            if output.status.success() {
+                let branch_output = String::from_utf8_lossy(&output.stdout);
+                let branch = branch_output.trim().to_string();
+                result.push_str(&format!("Current branch: {}\n\n", branch));
+            }
+        }
+
+        // Get status
+        if let Ok(output) = Command::new("git").args(["status", "--short"]).output() {
+            if output.status.success() {
+                let status_output = String::from_utf8_lossy(&output.stdout);
+                let status = status_output.trim().to_string();
+                result.push_str("Status:\n");
+                if status.is_empty() {
+                    result.push_str("Working tree clean\n");
+                } else {
+                    result.push_str(&status);
+                    result.push('\n');
+                }
+            }
+        }
+
+        // Get recent commits
+        if let Ok(output) = Command::new("git").args(["log", "--oneline", "-n", "5"]).output() {
+            if output.status.success() {
+                let log_output = String::from_utf8_lossy(&output.stdout);
+                let log = log_output.trim().to_string();
+                result.push_str("\nRecent commits:\n");
+                result.push_str(&log);
+            }
+        }
+
+        Ok(result)
+    }
 }
 
 #[tonic::async_trait]
-impl RemoteBackendServiceServer for RemoteBackendService {
+impl RemoteWorkspaceServiceServer for RemoteWorkspaceService {
     /// Get tool schemas
     async fn get_tool_schemas(
         &self,
@@ -247,5 +341,88 @@ impl RemoteBackendServiceServer for RemoteBackendService {
                 approval_requirements,
             },
         ))
+    }
+
+    /// Get environment information for the remote workspace
+    async fn get_environment_info(
+        &self,
+        request: Request<crate::proto::GetEnvironmentInfoRequest>,
+    ) -> Result<Response<crate::proto::GetEnvironmentInfoResponse>, Status> {
+        use std::process::Command;
+
+        let req = request.into_inner();
+        
+        // Use the provided working directory or current directory
+        let working_directory = if let Some(dir) = req.working_directory {
+            dir
+        } else {
+            std::env::current_dir()
+                .map(|p| p.to_string_lossy().to_string())
+                .map_err(|e| Status::internal(format!("Failed to get current directory: {}", e)))?
+        };
+
+        // Change to the working directory if specified
+        if working_directory != std::env::current_dir().unwrap().to_string_lossy() {
+            if let Err(e) = std::env::set_current_dir(&working_directory) {
+                return Err(Status::invalid_argument(format!(
+                    "Failed to change to directory {}: {}",
+                    working_directory, e
+                )));
+            }
+        }
+
+        // Check if it's a git repo
+        let is_git_repo = std::path::Path::new(".git").exists() || {
+            Command::new("git")
+                .args(["rev-parse", "--is-inside-work-tree"])
+                .output()
+                .map(|output| output.status.success())
+                .unwrap_or(false)
+        };
+
+        // Get platform information
+        let platform = if cfg!(target_os = "windows") {
+            "windows"
+        } else if cfg!(target_os = "macos") {
+            "macos"
+        } else if cfg!(target_os = "linux") {
+            "linux"
+        } else {
+            "unknown"
+        }.to_string();
+
+        // Get current date (simplified)
+        let date = "2025-06-17".to_string(); // TODO: Use proper date formatting
+
+        // Get directory structure (simplified for now)
+        let directory_structure = self.get_directory_structure().unwrap_or_else(|_| {
+            format!("Failed to read directory structure from {}", working_directory)
+        });
+
+        // Get git status if it's a git repo
+        let git_status = if is_git_repo {
+            self.get_git_status().ok()
+        } else {
+            None
+        };
+
+        // Read README.md if it exists
+        let readme_content = std::fs::read_to_string("README.md").ok();
+
+        // Read CLAUDE.md if it exists
+        let claude_md_content = std::fs::read_to_string("CLAUDE.md").ok();
+
+        let response = crate::proto::GetEnvironmentInfoResponse {
+            working_directory,
+            is_git_repo,
+            platform,
+            date,
+            directory_structure,
+            git_status,
+            readme_content,
+            claude_md_content,
+        };
+
+        Ok(Response::new(response))
     }
 }

--- a/remote-backend/tests/service_test.rs
+++ b/remote-backend/tests/service_test.rs
@@ -1,15 +1,15 @@
 use remote_backend::proto::{
     ExecuteToolRequest, HealthStatus,
-    remote_backend_service_server::RemoteBackendService as RemoteBackendServiceTrait,
+    remote_workspace_service_server::RemoteWorkspaceService as RemoteWorkspaceServiceTrait,
 };
-use remote_backend::remote_backend_service::RemoteBackendService;
+use remote_backend::remote_backend_service::RemoteWorkspaceService;
 use serde_json::json;
 use tonic::Request;
 
 /// Test service creation
 #[tokio::test]
 async fn test_service_creation() {
-    let service = RemoteBackendService::new();
+    let service = RemoteWorkspaceService::new();
     assert!(service.is_ok());
 
     let service = service.unwrap();
@@ -24,7 +24,7 @@ async fn test_service_creation() {
 /// Test health check endpoint
 #[tokio::test]
 async fn test_health_check() {
-    let service = RemoteBackendService::new().unwrap();
+    let service = RemoteWorkspaceService::new().unwrap();
     let request = Request::new(());
 
     let response = service.health(request).await;
@@ -38,7 +38,7 @@ async fn test_health_check() {
 /// Test get_tool_schemas endpoint
 #[tokio::test]
 async fn test_get_tool_schemas() {
-    let service = RemoteBackendService::new().unwrap();
+    let service = RemoteWorkspaceService::new().unwrap();
     let request = Request::new(());
 
     let response = service.get_tool_schemas(request).await;
@@ -59,7 +59,7 @@ async fn test_get_tool_schemas() {
 /// Test tool execution with valid tool
 #[tokio::test]
 async fn test_execute_tool_ls() {
-    let service = RemoteBackendService::new().unwrap();
+    let service = RemoteWorkspaceService::new().unwrap();
 
     let request = Request::new(ExecuteToolRequest {
         tool_call_id: "test-123".to_string(),
@@ -88,7 +88,7 @@ async fn test_execute_tool_ls() {
 /// Test tool execution with unknown tool
 #[tokio::test]
 async fn test_execute_unknown_tool() {
-    let service = RemoteBackendService::new().unwrap();
+    let service = RemoteWorkspaceService::new().unwrap();
 
     let request = Request::new(ExecuteToolRequest {
         tool_call_id: "test-456".to_string(),
@@ -109,7 +109,7 @@ async fn test_execute_unknown_tool() {
 /// Test tool execution with invalid parameters
 #[tokio::test]
 async fn test_execute_tool_invalid_params() {
-    let service = RemoteBackendService::new().unwrap();
+    let service = RemoteWorkspaceService::new().unwrap();
 
     let request = Request::new(ExecuteToolRequest {
         tool_call_id: "test-789".to_string(),
@@ -129,7 +129,7 @@ async fn test_execute_tool_invalid_params() {
 /// Test tool cancellation
 #[tokio::test]
 async fn test_tool_cancellation() {
-    let service = RemoteBackendService::new().unwrap();
+    let service = RemoteWorkspaceService::new().unwrap();
 
     // Execute a long-running command
     let request = Request::new(ExecuteToolRequest {
@@ -158,7 +158,7 @@ async fn test_tool_cancellation() {
 /// Test get_agent_info endpoint
 #[tokio::test]
 async fn test_get_agent_info() {
-    let service = RemoteBackendService::new().unwrap();
+    let service = RemoteWorkspaceService::new().unwrap();
     let request = Request::new(());
 
     let response = service.get_agent_info(request).await;
@@ -174,7 +174,7 @@ async fn test_get_agent_info() {
 fn test_with_tools_constructor() {
     use tools::tools::read_only_workspace_tools;
 
-    let service = RemoteBackendService::with_tools(read_only_workspace_tools()).unwrap();
+    let service = RemoteWorkspaceService::with_tools(read_only_workspace_tools()).unwrap();
     let tools = service.get_supported_tools();
 
     // Should only have read-only tools


### PR DESCRIPTION
- Introduce Workspace trait that unifies environment info and tool execution
- Refactor ToolExecutor to check workspace tools first, then external backends
- Remove WorkspaceBackendAdapter - workspaces no longer pretend to be backends
- Rename RemoteBackend to RemoteWorkspace throughout codebase and proto
- Remove ContainerWorkspace - use RemoteWorkspace with container agents instead
- Fix EnvironmentInfo to be workspace-aware (local vs remote)
- Separate workspace tools from external tools (dispatch_agent, web_fetch)

This fixes the issue where system prompts always showed local environment info even when using remote workspaces.