### PR TITLE
fix: view mode changes not applying to new messages

### DIFF
--- a/conductor/src/tui/mod.rs
+++ b/conductor/src/tui/mod.rs
@@ -401,7 +401,7 @@ impl Tui {
                             match event {
                                 Event::Resize(_, _) => {
                                     debug!(target:"tui.run", "Terminal resized");
-                                    self.view_model.message_list_state.clear_height_cache();
+                                    
                                     needs_redraw = true;
                                     // The widget will handle recalculating sizes internally
                                 }
@@ -738,7 +738,7 @@ impl Tui {
         input_mode: InputMode,
         current_model: &str,
         current_approval_info: Option<&tools::ToolCall>,
-        content_cache: std::sync::Arc<std::sync::Mutex<ContentCache>>,
+        content_cache: std::sync::Arc<std::sync::RwLock<ContentCache>>,
     ) -> Result<()> {
         let total_area = f.area();
         let input_height = (textarea.lines().len() as u16 + 2)
@@ -882,7 +882,7 @@ impl Tui {
                         Some(ViewMode::Detailed) => None,
                     };
                     // Clear caches when view mode changes
-                    self.view_model.message_list_state.clear_height_cache();
+                    
                     self.view_model.clear_content_cache();
                     return Ok(None);
                 }
@@ -894,7 +894,7 @@ impl Tui {
                         .view_prefs
                         .global_override = Some(ViewMode::Detailed);
                     // Clear caches when view mode changes
-                    self.view_model.message_list_state.clear_height_cache();
+                    
                     self.view_model.clear_content_cache();
                     return Ok(None);
                 }
@@ -906,7 +906,7 @@ impl Tui {
                         .view_prefs
                         .global_override = Some(ViewMode::Compact);
                     // Clear cache when view mode changes
-                    self.view_model.message_list_state.clear_height_cache();
+                    
                     return Ok(None);
                 }
 

--- a/conductor/src/tui/widgets/cached_renderer.rs
+++ b/conductor/src/tui/widgets/cached_renderer.rs
@@ -1,5 +1,5 @@
 use ratatui::{buffer::Buffer, layout::Rect};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, RwLock};
 
 use crate::tui::widgets::message_list::{MessageContent, ViewMode};
 use crate::tui::state::content_cache::ContentCache;
@@ -9,11 +9,11 @@ use super::content_renderer::{ContentRenderer, DefaultContentRenderer};
 /// but always uses the original rendering logic for drawing
 pub struct CachedContentRenderer {
     inner: DefaultContentRenderer,
-    cache: Arc<Mutex<ContentCache>>,
+    cache: Arc<RwLock<ContentCache>>,
 }
 
 impl CachedContentRenderer {
-    pub fn new(cache: Arc<Mutex<ContentCache>>) -> Self {
+    pub fn new(cache: Arc<RwLock<ContentCache>>) -> Self {
         Self {
             inner: DefaultContentRenderer,
             cache,
@@ -30,7 +30,7 @@ impl ContentRenderer for CachedContentRenderer {
 
     fn calculate_height(&self, content: &MessageContent, mode: ViewMode, width: u16) -> u16 {
         // Only cache height calculations
-        if let Ok(mut cache) = self.cache.lock() {
+        if let Ok(mut cache) = self.cache.write() {
             cache.get_or_parse_height(
                 content,
                 mode,


### PR DESCRIPTION
- Refactor TUI caching system from Mutex to RwLock for better concurrency
- Remove duplicate height caching in MessageListState
- Centralize all content caching in ContentCache
- Consolidate view mode determination logic
- Fix visual bug where view mode switches didn't affect newly rendered messages