### PR TITLE
fix: replace blocking std::process::Command with git2 crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -834,6 +834,7 @@ dependencies = [
  "futures-util",
  "fuzzy-matcher",
  "gethostname",
+ "git2",
  "glob",
  "globset",
  "hex",
@@ -922,6 +923,7 @@ dependencies = [
  "conductor-tools",
  "fuzzy-matcher",
  "gethostname",
+ "git2",
  "ignore",
  "prost",
  "prost-types",
@@ -1778,6 +1780,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
+name = "git2"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2deb07a133b1520dc1a5690e9bd08950108873d7ed5de38dcc74d3b5ebffa110"
+dependencies = [
+ "bitflags 2.9.0",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "openssl-probe",
+ "openssl-sys",
+ "url",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2439,6 +2456,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
+name = "libgit2-sys"
+version = "0.18.2+1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c42fe03df2bd3c53a3a9c7317ad91d80c81cd1fb0caec8d7cc4cd2bfa10c222"
+dependencies = [
+ "cc",
+ "libc",
+ "libssh2-sys",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+]
+
+[[package]]
 name = "libloading"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2471,6 +2502,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf4e226dcd58b4be396f7bd3c20da8fdee2911400705297ba7d2d7cc2c30f716"
 dependencies = [
  "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "libssh2-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "220e4f05ad4a218192533b300327f5150e809b54c4ec83b5a1d91833601811b9"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b70e7a7df205e92a1a4cd9aaae7898dac0aa555503cc0a649494d0d60e7651d"
+dependencies = [
+ "cc",
+ "libc",
  "pkg-config",
  "vcpkg",
 ]

--- a/crates/conductor-core/Cargo.toml
+++ b/crates/conductor-core/Cargo.toml
@@ -67,6 +67,7 @@ gethostname = "0.5"
 lazy_static = "1.5.0"
 schemars = { version = "0.8", optional = true }
 fuzzy-matcher = "0.3.7"
+git2 = "0.20.2"
 
 
 [build-dependencies]

--- a/crates/conductor-core/src/workspace/local.rs
+++ b/crates/conductor-core/src/workspace/local.rs
@@ -235,11 +235,7 @@ mod tests {
         let temp_dir = tempdir().unwrap();
 
         // Create a git repo
-        std::process::Command::new("git")
-            .args(["init"])
-            .current_dir(temp_dir.path())
-            .output()
-            .unwrap();
+        git2::Repository::init(temp_dir.path()).unwrap();
 
         let workspace = LocalWorkspace::with_path(temp_dir.path().to_path_buf())
             .await

--- a/crates/conductor-remote-workspace/Cargo.toml
+++ b/crates/conductor-remote-workspace/Cargo.toml
@@ -37,3 +37,4 @@ conductor-tools = { path = "../conductor-tools" }
 fuzzy-matcher = "0.3.7"
 ignore = "0.4.23"
 tokio-stream = "0.1.17"
+git2 = "0.20.2"


### PR DESCRIPTION
- Replace all git command executions with git2 library calls
- Update environment.rs to use git2::Repository for git operations
- Update remote_workspace_service.rs to use git2 for git status
- Update test to use git2::Repository::init instead of command
- Handle unborn branch case gracefully in new repos
- Add git2 dependency to conductor-core and conductor-remote-workspace