### PR TITLE
feat: Refactor slash command parsing and handling

### DIFF
--- a/crates/conductor-core/src/app/command.rs
+++ b/crates/conductor-core/src/app/command.rs
@@ -1,5 +1,6 @@
 use crate::app::Message;
 use crate::app::agent_executor::ApprovalDecision;
+use crate::app::conversation::AppCommandType;
 use conductor_tools::ToolCall;
 use std::collections::HashSet;
 use tokio::sync::oneshot;
@@ -23,7 +24,7 @@ pub enum AppCommand {
         always: bool,
     },
     /// Execute a slash command.
-    ExecuteCommand(String),
+    ExecuteCommand(AppCommandType),
     /// Execute a bash command directly (bypassing AI)
     ExecuteBashCommand { command: String },
     /// Cancel processing.

--- a/crates/conductor-grpc/src/grpc/conversion_tests.rs
+++ b/crates/conductor-grpc/src/grpc/conversion_tests.rs
@@ -288,7 +288,7 @@ prop_compose! {
     fn arb_app_command()(
         variant in 0..4usize,
         user_input in ".*",
-        command in "[a-z ]+",
+        command in prop::sample::select(vec!["model", "clear", "compact", "cancel", "help"]),
         bash_command in "[a-z ]+",
         tool_id in "[a-zA-Z0-9-]+",
         approved in prop::bool::ANY,
@@ -296,7 +296,7 @@ prop_compose! {
     ) -> AppCommand {
         match variant {
             0 => AppCommand::ProcessUserInput(user_input),
-            1 => AppCommand::ExecuteCommand(command),
+            1 => AppCommand::ExecuteCommand(AppCommandType::parse(command).unwrap()),
             2 => AppCommand::ExecuteBashCommand { command: bash_command },
             _ => AppCommand::HandleToolResponse { id: tool_id, approved, always },
         }
@@ -588,7 +588,7 @@ proptest! {
 
         let expected = match &command {
             AppCommand::ProcessUserInput(text) => ExpectedResult::ProcessUserInput(text.clone()),
-            AppCommand::ExecuteCommand(cmd) => ExpectedResult::ExecuteCommand(cmd.clone()),
+            AppCommand::ExecuteCommand(cmd) => ExpectedResult::ExecuteCommand(cmd.as_command_str()),
             AppCommand::ExecuteBashCommand { command } => ExpectedResult::ExecuteBashCommand(command.clone()),
             AppCommand::HandleToolResponse { id, approved, always } => ExpectedResult::HandleToolResponse {
                 id: id.clone(),

--- a/crates/conductor-grpc/src/grpc/server.rs
+++ b/crates/conductor-grpc/src/grpc/server.rs
@@ -717,8 +717,14 @@ async fn handle_client_message(
             }
 
             client_message::Message::ExecuteCommand(execute_command) => {
-                let app_command =
-                    conductor_core::app::AppCommand::ExecuteCommand(execute_command.command);
+                use conductor_core::app::conversation::AppCommandType;
+                let app_cmd_type = match AppCommandType::parse(&execute_command.command) {
+                    Ok(cmd) => cmd,
+                    Err(e) => {
+                        return Err(format!("Failed to parse command: {e}").into());
+                    }
+                };
+                let app_command = conductor_core::app::AppCommand::ExecuteCommand(app_cmd_type);
                 session_manager
                     .send_command(&client_message.session_id, app_command)
                     .await

--- a/crates/conductor-tui/src/error.rs
+++ b/crates/conductor-tui/src/error.rs
@@ -52,6 +52,10 @@ pub enum Error {
     /// gRPC errors from conductor-grpc
     #[error("gRPC error: {0}")]
     Grpc(#[from] conductor_grpc::GrpcError),
+
+    /// TUI command parsing errors
+    #[error("TUI command parsing error: {0}")]
+    TuiCommandParsing(#[from] crate::tui::commands::TuiCommandError),
 }
 
 // Convert notify-rust errors to our error type

--- a/crates/conductor-tui/src/tui/commands.rs
+++ b/crates/conductor-tui/src/tui/commands.rs
@@ -1,0 +1,166 @@
+use conductor_core::app::conversation::{AppCommandType as CoreCommand, SlashCommandError};
+use std::fmt;
+use std::str::FromStr;
+use thiserror::Error;
+
+/// Errors that can occur when parsing TUI commands
+#[derive(Debug, Error)]
+pub enum TuiCommandError {
+    UnknownCommand(String),
+    CoreParseError(#[from] SlashCommandError),
+}
+
+// Custom Display implementation to provide consistent error messages
+impl fmt::Display for TuiCommandError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            TuiCommandError::UnknownCommand(cmd) => write!(f, "Unknown command: {cmd}"),
+            TuiCommandError::CoreParseError(core_err) => {
+                // Provide consistent formatting for all error types
+                match core_err {
+                    SlashCommandError::UnknownCommand(cmd) => write!(f, "Unknown command: {cmd}"),
+                    SlashCommandError::InvalidFormat(msg) => {
+                        write!(f, "Invalid command format: {msg}")
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// TUI-specific commands that don't belong in the core
+#[derive(Debug, Clone, PartialEq)]
+pub enum TuiCommand {
+    /// Reload files in the TUI
+    ReloadFiles,
+}
+
+/// Unified command type that can represent either TUI or Core commands
+#[derive(Debug, Clone, PartialEq)]
+pub enum AppCommand {
+    /// A TUI-specific command
+    Tui(TuiCommand),
+    /// A core command that gets passed down
+    Core(CoreCommand),
+}
+
+impl TuiCommand {
+    /// Parse a command string into a TuiCommand (without leading slash)
+    fn parse_without_slash(command: &str) -> Result<Self, TuiCommandError> {
+        match command {
+            "reload-files" => Ok(TuiCommand::ReloadFiles),
+            _ => Err(TuiCommandError::UnknownCommand(command.to_string())),
+        }
+    }
+
+    /// Convert the command to its string representation (without leading slash)
+    pub fn as_command_str(&self) -> &'static str {
+        match self {
+            TuiCommand::ReloadFiles => "reload-files",
+        }
+    }
+}
+
+impl AppCommand {
+    /// Parse a command string into an AppCommand
+    pub fn parse(input: &str) -> Result<Self, TuiCommandError> {
+        // Trim whitespace and remove leading slash if present
+        let command = input.trim();
+        let command = command.strip_prefix('/').unwrap_or(command);
+
+        // Split to get just the command name (without args)
+        let cmd_name = command.split_whitespace().next().unwrap_or("");
+
+        // First try to parse as a TUI command
+        match TuiCommand::parse_without_slash(cmd_name) {
+            Ok(tui_cmd) => Ok(AppCommand::Tui(tui_cmd)),
+            Err(_) => {
+                // If not a TUI command, try to parse as a core command
+                CoreCommand::parse(input)
+                    .map(AppCommand::Core)
+                    .map_err(TuiCommandError::from)
+            }
+        }
+    }
+
+    /// Convert the command back to its string representation (with leading slash)
+    pub fn as_command_str(&self) -> String {
+        match self {
+            AppCommand::Tui(tui_cmd) => format!("/{}", tui_cmd.as_command_str()),
+            AppCommand::Core(core_cmd) => core_cmd.to_string(),
+        }
+    }
+}
+
+impl fmt::Display for TuiCommand {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "/{}", self.as_command_str())
+    }
+}
+
+impl fmt::Display for AppCommand {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.as_command_str())
+    }
+}
+
+impl FromStr for AppCommand {
+    type Err = TuiCommandError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::parse(s)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_tui_commands() {
+        assert_eq!(
+            AppCommand::parse("/reload-files").unwrap(),
+            AppCommand::Tui(TuiCommand::ReloadFiles)
+        );
+        assert_eq!(
+            AppCommand::parse("reload-files").unwrap(),
+            AppCommand::Tui(TuiCommand::ReloadFiles)
+        );
+    }
+
+    #[test]
+    fn test_parse_core_commands() {
+        assert!(matches!(
+            AppCommand::parse("/help").unwrap(),
+            AppCommand::Core(CoreCommand::Help)
+        ));
+        assert!(matches!(
+            AppCommand::parse("/clear").unwrap(),
+            AppCommand::Core(CoreCommand::Clear)
+        ));
+        assert!(matches!(
+            AppCommand::parse("/model opus").unwrap(),
+            AppCommand::Core(CoreCommand::Model { .. })
+        ));
+    }
+
+    #[test]
+    fn test_display() {
+        assert_eq!(
+            AppCommand::Tui(TuiCommand::ReloadFiles).to_string(),
+            "/reload-files"
+        );
+        assert_eq!(AppCommand::Core(CoreCommand::Help).to_string(), "/help");
+    }
+
+    #[test]
+    fn test_error_formatting() {
+        // Test TUI unknown command error
+        let err = AppCommand::parse("/unknown-tui-cmd").unwrap_err();
+        assert_eq!(err.to_string(), "Unknown command: unknown-tui-cmd");
+
+        // Test core unknown command error (will be caught by core parser)
+        let err = AppCommand::parse("/unknown-core-cmd").unwrap_err();
+        assert_eq!(err.to_string(), "Unknown command: unknown-core-cmd");
+    }
+}

--- a/crates/conductor-tui/src/tui/widgets/chat_list.rs
+++ b/crates/conductor-tui/src/tui/widgets/chat_list.rs
@@ -285,9 +285,6 @@ impl<'a> ChatList<'a> {
                         "/cancel".to_string()
                     }
                     conductor_core::app::conversation::AppCommandType::Help => "/help".to_string(),
-                    conductor_core::app::conversation::AppCommandType::Unknown { command } => {
-                        command.clone()
-                    }
                 };
 
                 // Get the full response text
@@ -538,18 +535,27 @@ impl<'a> ChatList<'a> {
                             UserContent::AppCommand { command, response } => {
                                 // Format command nicely
                                 let command_str = match command {
-                                    conductor_core::app::conversation::AppCommandType::Model { target } => {
+                                    conductor_core::app::conversation::AppCommandType::Model {
+                                        target,
+                                    } => {
                                         if let Some(model) = target {
                                             format!("/model {model}")
                                         } else {
                                             "/model".to_string()
                                         }
                                     }
-                                    conductor_core::app::conversation::AppCommandType::Compact => "/compact".to_string(),
-                                    conductor_core::app::conversation::AppCommandType::Clear => "/clear".to_string(),
-                                    conductor_core::app::conversation::AppCommandType::Cancel => "/cancel".to_string(),
-                                    conductor_core::app::conversation::AppCommandType::Help => "/help".to_string(),
-                                    conductor_core::app::conversation::AppCommandType::Unknown { command } => command.clone(),
+                                    conductor_core::app::conversation::AppCommandType::Compact => {
+                                        "/compact".to_string()
+                                    }
+                                    conductor_core::app::conversation::AppCommandType::Clear => {
+                                        "/clear".to_string()
+                                    }
+                                    conductor_core::app::conversation::AppCommandType::Cancel => {
+                                        "/cancel".to_string()
+                                    }
+                                    conductor_core::app::conversation::AppCommandType::Help => {
+                                        "/help".to_string()
+                                    }
                                 };
 
                                 // Add gutter if this is the first block

--- a/crates/conductor-tui/src/tui/widgets/formatters/dispatch_agent.rs
+++ b/crates/conductor-tui/src/tui/widgets/formatters/dispatch_agent.rs
@@ -106,7 +106,7 @@ impl ToolFormatter for DispatchAgentFormatter {
                 ToolResult::Error(error) => {
                     lines.push(separator_line(wrap_width, styles::DIM_TEXT));
                     lines.push(Line::from(Span::styled(
-                        format!("Error: {error}"),
+                        error.to_string(),
                         styles::ERROR_TEXT,
                     )));
                 }

--- a/crates/conductor-tui/src/tui/widgets/formatters/edit.rs
+++ b/crates/conductor-tui/src/tui/widgets/formatters/edit.rs
@@ -212,7 +212,7 @@ impl ToolFormatter for EditFormatter {
         if let Some(ToolResult::Error(error)) = result {
             lines.push(separator_line(wrap_width, styles::DIM_TEXT));
             lines.push(Line::from(Span::styled(
-                format!("Error: {error}"),
+                error.to_string(),
                 styles::ERROR_TEXT,
             )));
         }

--- a/crates/conductor-tui/src/tui/widgets/formatters/fetch.rs
+++ b/crates/conductor-tui/src/tui/widgets/formatters/fetch.rs
@@ -113,7 +113,7 @@ impl ToolFormatter for FetchFormatter {
                 ToolResult::Error(error) => {
                     lines.push(separator_line(wrap_width, styles::DIM_TEXT));
                     lines.push(Line::from(Span::styled(
-                        format!("Error: {error}"),
+                        error.to_string(),
                         styles::ERROR_TEXT,
                     )));
                 }

--- a/crates/conductor-tui/src/tui/widgets/formatters/replace.rs
+++ b/crates/conductor-tui/src/tui/widgets/formatters/replace.rs
@@ -89,7 +89,7 @@ impl ToolFormatter for ReplaceFormatter {
         // Show error if result is an error
         if let Some(ToolResult::Error(error)) = result {
             lines.push(Line::from(Span::styled(
-                format!("Error: {error}"),
+                error.to_string(),
                 styles::ERROR_TEXT,
             )));
         }

--- a/crates/conductor-tui/src/tui/widgets/formatters/todo_write.rs
+++ b/crates/conductor-tui/src/tui/widgets/formatters/todo_write.rs
@@ -99,7 +99,7 @@ impl ToolFormatter for TodoWriteFormatter {
         if let Some(ToolResult::Error(error)) = result {
             lines.push(separator_line(40, styles::DIM_TEXT));
             lines.push(Line::from(Span::styled(
-                format!("Error: {error}"),
+                error.to_string(),
                 styles::ERROR_TEXT,
             )));
         }

--- a/proto/streaming.proto
+++ b/proto/streaming.proto
@@ -92,16 +92,11 @@ message AppCommandType {
     bool compact = 3;
     bool cancel = 4;
     bool help = 5;
-    UnknownCommand unknown = 6;
   }
 }
 
 message ModelCommand {
   optional string target = 1;
-}
-
-message UnknownCommand {
-  string command = 1;
 }
 
 message CommandResponse {


### PR DESCRIPTION
This commit introduces a more robust and extensible slash command handling system.

Key changes:
- **Core Command Parsing**:  in  now has a  method that returns a , enabling better error handling for unknown or malformed commands. The  variant has been removed in favor of this.
- **TUI Command Layer**: A new  module separates TUI-specific commands (like ) from core backend commands.
- **Unified Parser**: The TUI now uses a unified parser that attempts to resolve a command as a TUI command first, then falls back to parsing it as a core command.
- **Error Propagation**: Parsing errors are now properly propagated from the core and displayed as notices in the TUI, improving user feedback.
- **gRPC Update**: The gRPC layer and protobuf definitions have been updated to reflect the new command structure, removing the  command type.

This refactoring makes the command system cleaner, separates concerns between the TUI and the core, and makes it easier to add new commands in the future.