### PR TITLE
feat: add bash command approval patterns and refactor approval system

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,20 @@ Read-only tools run automatically ( `view`, `grep`, `ls`, `glob`, `fetch`, `todo
 
 Headless mode pre-approves every built-in tool for convenience.
 
+### Bash Command Approval
+
+You can pre-approve specific bash commands using glob patterns in your session configuration:
+
+```toml
+[tool_config.tools.bash]
+approved_patterns = [
+    "git status",
+    "git log*",
+    "npm run*",
+    "cargo build*"
+]
+```
+
 ---
 
 ## Development

--- a/crates/conductor-core/src/app/command.rs
+++ b/crates/conductor-core/src/app/command.rs
@@ -5,6 +5,19 @@ use conductor_tools::ToolCall;
 use std::collections::HashSet;
 use tokio::sync::oneshot;
 
+/// Tool-specific approval payload for different types of tool approvals
+#[derive(Debug, Clone)]
+pub enum ApprovalType {
+    /// Denied approval for this specific tool call
+    Denied,
+    /// One-time approval for this specific tool call
+    Once,
+    /// Always approve this entire tool
+    AlwaysTool,
+    /// Always approve this specific bash command pattern
+    AlwaysBashPattern(String),
+}
+
 /// Defines messages the TUI can send *to* the `App` actor.
 #[derive(Debug)]
 pub enum AppCommand {
@@ -18,11 +31,7 @@ pub enum AppCommand {
         new_content: String,
     },
     /// Handle the user's decision on a tool approval request.
-    HandleToolResponse {
-        id: String,
-        approved: bool,
-        always: bool,
-    },
+    HandleToolResponse { id: String, approval: ApprovalType },
     /// Execute a slash command.
     ExecuteCommand(AppCommandType),
     /// Execute a bash command directly (bypassing AI)
@@ -40,6 +49,7 @@ pub enum AppCommand {
     RestoreConversation {
         messages: Vec<Message>,
         approved_tools: HashSet<String>,
+        approved_bash_patterns: HashSet<String>,
     },
     /// Request to send the current conversation state
     /// Used by TUI to populate display after session restoration

--- a/crates/conductor-core/src/session/manager.rs
+++ b/crates/conductor-core/src/session/manager.rs
@@ -487,6 +487,7 @@ impl SessionManager {
                 .send(AppCommand::RestoreConversation {
                     messages: session.state.messages.clone(),
                     approved_tools: session.state.approved_tools.clone(),
+                    approved_bash_patterns: session.state.approved_bash_patterns.clone(),
                 })
                 .await
                 .map_err(|_| SessionManagerError::CreationFailed {

--- a/crates/conductor-core/tests/tool_approval_test.rs
+++ b/crates/conductor-core/tests/tool_approval_test.rs
@@ -1,6 +1,8 @@
 type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 use conductor_core::api::Model;
-use conductor_core::app::{App, AppCommand, AppConfig, AppEvent, ApprovalDecision, ToolExecutor};
+use conductor_core::app::{
+    App, AppCommand, AppConfig, AppEvent, ApprovalDecision, ToolExecutor, command::ApprovalType,
+};
 use conductor_core::test_utils;
 use conductor_core::workspace::local::LocalWorkspace;
 use conductor_tools::ToolCall;
@@ -212,8 +214,7 @@ async fn test_always_approve_cascades_to_pending_tool_calls() -> Result<()> {
     command_tx_to_actor
         .send(AppCommand::HandleToolResponse {
             id: tool_call_id_1.clone(),
-            approved: true,
-            always: true,
+            approval: ApprovalType::AlwaysTool,
         })
         .await?;
 

--- a/crates/conductor-proto/build.rs
+++ b/crates/conductor-proto/build.rs
@@ -20,6 +20,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     tonic_build::configure()
         .build_server(true)
         .build_client(true)
+        .type_attribute(".", "#[allow(clippy::large_enum_variant)]")
         .compile_protos(
             &[
                 streaming_proto.to_str().unwrap(),

--- a/crates/conductor-tui/src/tui/handlers/approval.rs
+++ b/crates/conductor-tui/src/tui/handlers/approval.rs
@@ -1,7 +1,13 @@
+use crate::error::Error;
 use crate::error::Result;
 use crate::tui::{InputMode, Tui};
-use conductor_core::app::AppCommand;
+use conductor_core::app::{AppCommand, command::ApprovalType};
+use conductor_core::error::Error as CoreError;
+use conductor_tools::ToolError;
+use conductor_tools::tools::BASH_TOOL_NAME;
+use conductor_tools::tools::bash::BashParams;
 use ratatui::crossterm::event::{KeyCode, KeyEvent};
+use tracing::debug;
 
 impl Tui {
     pub async fn handle_approval_mode(&mut self, key: KeyEvent) -> Result<bool> {
@@ -12,30 +18,63 @@ impl Tui {
                     self.command_sink
                         .send_command(AppCommand::HandleToolResponse {
                             id: tool_call.id,
-                            approved: true,
-                            always: false,
+                            approval: ApprovalType::Once,
                         })
                         .await?;
                     self.input_mode = InputMode::Normal;
                 }
                 KeyCode::Char('a') | KeyCode::Char('A') => {
-                    // Approve always
-                    self.command_sink
-                        .send_command(AppCommand::HandleToolResponse {
-                            id: tool_call.id,
-                            approved: true,
-                            always: true,
-                        })
-                        .await?;
+                    debug!(target: "handle_approval_mode", "Approving tool call with ID '{}' and name '{}'", tool_call.id, tool_call.name);
+                    if tool_call.name == BASH_TOOL_NAME {
+                        debug!(target: "handle_approval_mode", "(Always) Approving bash command with ID '{}'", tool_call.id);
+                        // For bash commands, 'A' approves this specific command pattern
+                        let bash_params: BashParams =
+                            serde_json::from_value(tool_call.parameters.clone()).map_err(|e| {
+                                Error::Core(CoreError::Tool(ToolError::InvalidParams(
+                                    "bash".to_string(),
+                                    e.to_string(),
+                                )))
+                            })?;
+                        // Approve with the bash pattern payload
+                        self.command_sink
+                            .send_command(AppCommand::HandleToolResponse {
+                                id: tool_call.id,
+                                approval: ApprovalType::AlwaysBashPattern(
+                                    bash_params.command.clone(),
+                                ),
+                            })
+                            .await?;
+                    } else {
+                        // For non-bash tools, 'A' approves always
+                        self.command_sink
+                            .send_command(AppCommand::HandleToolResponse {
+                                id: tool_call.id,
+                                approval: ApprovalType::AlwaysTool,
+                            })
+                            .await?;
+                    }
                     self.input_mode = InputMode::Normal;
+                }
+                KeyCode::Char('l') | KeyCode::Char('L') => {
+                    if tool_call.name == BASH_TOOL_NAME {
+                        self.command_sink
+                            .send_command(AppCommand::HandleToolResponse {
+                                id: tool_call.id,
+                                approval: ApprovalType::AlwaysTool,
+                            })
+                            .await?;
+                        self.input_mode = InputMode::Normal;
+                    } else {
+                        // Put it back if not a bash command
+                        self.current_tool_approval = Some(tool_call);
+                    }
                 }
                 KeyCode::Char('n') | KeyCode::Char('N') | KeyCode::Esc => {
                     // Reject
                     self.command_sink
                         .send_command(AppCommand::HandleToolResponse {
                             id: tool_call.id,
-                            approved: false,
-                            always: false,
+                            approval: ApprovalType::Denied,
                         })
                         .await?;
                     self.input_mode = InputMode::Normal;

--- a/crates/conductor-tui/src/tui/widgets/input_panel.rs
+++ b/crates/conductor-tui/src/tui/widgets/input_panel.rs
@@ -534,20 +534,40 @@ impl StatefulWidget for InputPanel<'_> {
                 Line::from(""),
             ];
             approval_text.extend(preview_lines);
+            let is_bash_command = tool_call.name == "bash";
 
-            let title = Line::from(vec![
-                Span::raw(" Tool Approval Required "),
-                Span::raw("─ "),
-                Span::styled("[Y]", self.theme.style(Component::ToolSuccess)),
-                Span::styled(" once", Style::default()),
-                Span::raw(" "),
-                Span::styled("[A]", self.theme.style(Component::ToolSuccess)),
-                Span::styled("lways", Style::default()),
-                Span::raw(" "),
-                Span::styled("[N]", self.theme.style(Component::ToolError)),
-                Span::styled("o", Style::default()),
-                Span::raw(" "),
-            ]);
+            let title = if is_bash_command {
+                Line::from(vec![
+                    Span::raw(" Tool Approval Required "),
+                    Span::raw("─ "),
+                    Span::styled("[Y]", self.theme.style(Component::ToolSuccess)),
+                    Span::styled(" once", self.theme.style(Component::DimText)),
+                    Span::raw(" "),
+                    Span::styled("[A]", self.theme.style(Component::ToolSuccess)),
+                    Span::styled("lways (this command)", self.theme.style(Component::DimText)),
+                    Span::raw(" "),
+                    Span::styled("[L]", self.theme.style(Component::ToolSuccess)),
+                    Span::styled(" Always", self.theme.style(Component::DimText)),
+                    Span::raw(" "),
+                    Span::styled("[N]", self.theme.style(Component::ToolError)),
+                    Span::styled("o", self.theme.style(Component::DimText)),
+                    Span::raw(" "),
+                ])
+            } else {
+                Line::from(vec![
+                    Span::raw(" Tool Approval Required "),
+                    Span::raw("─ "),
+                    Span::styled("[Y]", self.theme.style(Component::ToolSuccess)),
+                    Span::styled(" once", self.theme.style(Component::DimText)),
+                    Span::raw(" "),
+                    Span::styled("[A]", self.theme.style(Component::ToolSuccess)),
+                    Span::styled("lways", self.theme.style(Component::DimText)),
+                    Span::raw(" "),
+                    Span::styled("[N]", self.theme.style(Component::ToolError)),
+                    Span::styled("o", self.theme.style(Component::DimText)),
+                    Span::raw(" "),
+                ])
+            };
 
             let approval_block = Paragraph::new(approval_text).block(
                 Block::default()

--- a/proto/streaming.proto
+++ b/proto/streaming.proto
@@ -256,6 +256,15 @@ message ToolApprovalResponse {
   ApprovalDecision decision = 2;
 }
 
+message ApprovalDecision {
+  oneof decision_type {
+    bool deny = 1;
+    bool once = 2;  // One-time approval
+    bool always_tool = 3;  // Always approve this tool
+    string always_bash_pattern = 4;  // Always approve this bash pattern
+  }
+}
+
 message SubscribeRequest {
   repeated string event_types = 1;
   optional uint64 since_sequence = 2;
@@ -564,6 +573,19 @@ message SessionToolConfig {
   map<string, string> metadata = 2;
   ToolVisibility visibility = 3;
   ToolApprovalPolicy approval_policy = 4;
+  map<string, ToolSpecificConfig> tools = 5;
+}
+
+// Tool-specific configuration
+message ToolSpecificConfig {
+  oneof config {
+    BashToolConfig bash = 1;
+  }
+}
+
+// Bash tool configuration
+message BashToolConfig {
+  repeated string approved_patterns = 1;
 }
 
 message ToolVisibility {
@@ -703,13 +725,6 @@ enum ToolCallStatus {
   TOOL_CALL_STATUS_EXECUTING = 4;
   TOOL_CALL_STATUS_COMPLETED = 5;
   TOOL_CALL_STATUS_FAILED = 6;
-}
-
-enum ApprovalDecision {
-  APPROVAL_DECISION_UNSPECIFIED = 0;
-  APPROVAL_DECISION_APPROVE = 1;
-  APPROVAL_DECISION_DENY = 2;
-  APPROVAL_DECISION_ALWAYS_APPROVE = 3;
 }
 
 enum ContainerRuntime {

--- a/schemas/session.schema.json
+++ b/schemas/session.schema.json
@@ -303,6 +303,20 @@
         }
       ]
     },
+    "PartialBashConfig": {
+      "type": "object",
+      "properties": {
+        "approved_patterns": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "PartialToolConfig": {
       "type": "object",
       "properties": {
@@ -325,6 +339,16 @@
             "$ref": "#/definitions/BackendConfig"
           }
         },
+        "tools": {
+          "default": null,
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": {
+            "$ref": "#/definitions/PartialToolSpecificConfig"
+          }
+        },
         "visibility": {
           "anyOf": [
             {
@@ -337,6 +361,13 @@
         }
       },
       "additionalProperties": false
+    },
+    "PartialToolSpecificConfig": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/PartialBashConfig"
+        }
+      ]
     },
     "PartialWorkspaceConfig": {
       "oneOf": [


### PR DESCRIPTION
- Introduce bash command approval patterns in session config
- Replace bool-based approval with ApprovalType enum (Denied/Once/AlwaysTool/AlwaysBashPattern)
- Add glob pattern matching for bash commands (e.g., 'git *', 'npm run*')
- Update TUI to show context-aware approval options for bash commands