### PR TITLE
refactor: replace vec-based ChatStore with IndexMap for stable key-based access

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1030,6 +1030,7 @@ dependencies = [
  "dirs 6.0.0",
  "fuzzy-matcher",
  "http 1.3.1",
+ "indexmap 2.10.0",
  "itertools 0.12.1",
  "lazy_static",
  "notify-rust",

--- a/crates/conductor-tui/Cargo.toml
+++ b/crates/conductor-tui/Cargo.toml
@@ -57,6 +57,7 @@ tui-big-text = "0.7.1"
 syntect = "5.2.0"
 strum = { version = "0.27.1", features = ["derive"] }
 strum_macros = "0.27.1"
+indexmap = { version = "2.0", features = ["std"] }
 
 [dev-dependencies]
 conductor-proto = { path = "../conductor-proto" }

--- a/crates/conductor-tui/src/tui/events/processor.rs
+++ b/crates/conductor-tui/src/tui/events/processor.rs
@@ -54,8 +54,8 @@ pub struct ProcessingContext<'a> {
     pub messages_updated: &'a mut bool,
     /// Current thread ID (None until first message)
     pub current_thread: Option<uuid::Uuid>,
-    /// Track in-flight operations (operation_id -> row_index)
-    pub in_flight_operations: &'a mut std::collections::HashMap<uuid::Uuid, usize>,
+    /// Track in-flight operations
+    pub in_flight_operations: &'a mut std::collections::HashSet<uuid::Uuid>,
 }
 
 #[async_trait]

--- a/crates/conductor-tui/src/tui/state/chat_store.rs
+++ b/crates/conductor-tui/src/tui/state/chat_store.rs
@@ -3,18 +3,42 @@
 use crate::tui::model::{ChatItem, MessageRow, RowId};
 use conductor_core::app::conversation::Message;
 
+use indexmap::IndexMap;
 use std::collections::{HashMap, HashSet};
 use uuid::Uuid;
 
+/// Stable key for accessing chat items
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct ChatItemKey(u64);
+
 /// Storage for chat items (messages and meta rows)
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Clone)]
 pub struct ChatStore {
-    /// All chat items for the current thread
-    items: Vec<ChatItem>,
-    /// Fast lookup id -> index
-    index: HashMap<RowId, usize>,
+    /// All chat items stored in order with O(1) key-based access
+    items: IndexMap<ChatItemKey, ChatItem>,
+    /// Fast lookup id -> key
+    id_to_key: HashMap<RowId, ChatItemKey>,
+    /// Key generator
+    next_key: u64,
     /// Current thread ID
     current_thread: Option<Uuid>,
+    /// Fast lookup for pending tool calls (tool_id -> key)
+    pending_tool_keys: HashMap<String, ChatItemKey>,
+    /// Fast lookup for in-flight operations (operation_id -> key)
+    in_flight_op_keys: HashMap<Uuid, ChatItemKey>,
+}
+
+impl Default for ChatStore {
+    fn default() -> Self {
+        Self {
+            items: IndexMap::new(),
+            id_to_key: HashMap::new(),
+            next_key: 0,
+            current_thread: None,
+            pending_tool_keys: HashMap::new(),
+            in_flight_op_keys: HashMap::new(),
+        }
+    }
 }
 
 impl ChatStore {
@@ -42,29 +66,63 @@ impl ChatStore {
         self.items.is_empty()
     }
 
-    /// Immutable slice of all items
-    pub fn as_slice(&self) -> &[ChatItem] {
-        &self.items
+    /// Get all items as a vector of references
+    pub fn as_vec(&self) -> Vec<&ChatItem> {
+        self.items.values().collect()
     }
 
-    /// Push a new item and return its index
-    pub fn push(&mut self, item: ChatItem) -> usize {
-        let idx = self.items.len();
-        self.index.insert(item.id().to_string(), idx);
+    /// Iterate over all items in order
+    pub fn items(&self) -> impl Iterator<Item = &ChatItem> + '_ {
+        self.items.values()
+    }
+
+    /// Get items as a slice for compatibility (allocates a Vec)
+    pub fn to_vec(&self) -> Vec<ChatItem> {
+        self.items.values().cloned().collect()
+    }
+
+    /// Borrow items as a vector for zero-copy iteration
+    pub fn as_items(&self) -> Vec<&ChatItem> {
+        self.items.values().collect()
+    }
+
+    /// Generate a new key
+    fn generate_key(&mut self) -> ChatItemKey {
+        let key = ChatItemKey(self.next_key);
+        self.next_key += 1;
+        key
+    }
+
+    /// Push a new item and return its key
+    pub fn push(&mut self, item: ChatItem) -> ChatItemKey {
+        let id = item.id().to_string();
+        let key = self.generate_key();
 
         // If this is the first message and we don't have a thread set, use its thread
         if self.current_thread.is_none() {
-            if let ChatItem::Message(row) = &item {
+            if let ChatItem::Message(ref row) = item {
                 self.current_thread = Some(*row.inner.thread_id());
             }
         }
 
-        self.items.push(item);
-        idx
+        // Track transient items for fast lookups
+        match &item {
+            ChatItem::PendingToolCall { tool_call, .. } => {
+                self.pending_tool_keys.insert(tool_call.id.clone(), key);
+            }
+            ChatItem::InFlightOperation { operation_id, .. } => {
+                self.in_flight_op_keys.insert(*operation_id, key);
+            }
+            _ => {}
+        }
+
+        self.items.insert(key, item);
+        self.id_to_key.insert(id, key);
+        key
     }
 
     /// Add a message row
-    pub fn add_message(&mut self, message: Message) -> usize {
+    pub fn add_message(&mut self, message: Message) -> ChatItemKey {
         let row = MessageRow::new(message);
 
         if self.current_thread.is_none() {
@@ -82,37 +140,62 @@ impl ChatStore {
     }
 
     /// Add a pending tool call
-    pub fn add_pending_tool(&mut self, item: ChatItem) -> usize {
+    pub fn add_pending_tool(&mut self, item: ChatItem) -> ChatItemKey {
         self.push(item)
     }
 
-    /// Remove an item by index
+    /// Remove an item by index (for backwards compatibility)
     pub fn remove(&mut self, idx: usize) {
-        if idx < self.items.len() {
-            let item = self.items.remove(idx);
-            // Remove from index
-            self.index.remove(item.id());
-            // Rebuild index to fix indices after removal
-            self.rebuild_index();
+        if let Some((key, _)) = self.items.get_index(idx) {
+            let key = *key;
+            self.remove_by_key(key);
+        }
+    }
+
+    /// Remove an item by its key
+    pub fn remove_by_key(&mut self, key: ChatItemKey) {
+        if let Some(item) = self.items.shift_remove(&key) {
+            // Remove from id lookup
+            self.id_to_key.remove(item.id());
+
+            // Remove from transient tracking maps
+            match &item {
+                ChatItem::PendingToolCall { tool_call, .. } => {
+                    self.pending_tool_keys.remove(&tool_call.id);
+                }
+                ChatItem::InFlightOperation { operation_id, .. } => {
+                    self.in_flight_op_keys.remove(operation_id);
+                }
+                _ => {}
+            }
+        }
+    }
+
+    /// Remove an item by its ID
+    pub fn remove_by_id(&mut self, id: &str) {
+        if let Some(&key) = self.id_to_key.get(id) {
+            self.remove_by_key(key);
         }
     }
 
     /// Clear all items
     pub fn clear(&mut self) {
         self.items.clear();
-        self.index.clear();
+        self.id_to_key.clear();
+        self.pending_tool_keys.clear();
+        self.in_flight_op_keys.clear();
     }
 
     /// Get mutable reference by id
     pub fn get_mut_by_id(&mut self, id: &RowId) -> Option<&mut ChatItem> {
-        let idx = self.lookup(id)?;
-        self.items.get_mut(idx)
+        let key = self.lookup(id)?;
+        self.items.get_mut(&key)
     }
 
     /// Get immutable reference by id
     pub fn get_by_id(&self, id: &RowId) -> Option<&ChatItem> {
-        let idx = self.lookup(id)?;
-        self.items.get(idx)
+        let key = self.lookup(id)?;
+        self.items.get(&key)
     }
 
     /// Retain all messages that are either in the selected thread **or** are
@@ -126,7 +209,7 @@ impl ChatStore {
         let mut live_ids = HashSet::new();
         let mut queue: Vec<String> = self
             .items
-            .iter()
+            .values()
             .filter_map(|item| match item {
                 ChatItem::Message(row) if *row.inner.thread_id() == keep_thread_id => {
                     Some(row.inner.id().to_string())
@@ -137,7 +220,7 @@ impl ChatStore {
 
         let message_map: HashMap<String, &MessageRow> = self
             .items
-            .iter()
+            .values()
             .filter_map(|item| {
                 if let ChatItem::Message(row) = item {
                     Some((row.inner.id().to_string(), row))
@@ -160,19 +243,28 @@ impl ChatStore {
             }
         }
 
-        self.items.retain(|item| match item {
-            ChatItem::Message(row) => live_ids.contains(row.inner.id()),
-            _ => true,
-        });
+        // Remove items that are not in the live set
+        let keys_to_remove: Vec<ChatItemKey> = self
+            .items
+            .iter()
+            .filter_map(|(&key, item)| match item {
+                ChatItem::Message(row) if !live_ids.contains(row.inner.id()) => Some(key),
+                ChatItem::Message(_) => None,
+                _ => None,
+            })
+            .collect();
 
-        self.rebuild_index();
+        for key in keys_to_remove {
+            self.remove_by_key(key);
+        }
+
         self.current_thread = Some(keep_thread_id);
     }
 
     /// Find messages by parent ID
     pub fn find_by_parent(&self, parent_id: &str) -> Vec<&ChatItem> {
         self.items
-            .iter()
+            .values()
             .filter(|item| {
                 if let ChatItem::Message(row) = item {
                     row.inner.parent_message_id() == Some(parent_id)
@@ -185,28 +277,28 @@ impl ChatStore {
 
     /// Iterator over mutable items
     pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut ChatItem> {
-        self.items.iter_mut()
+        self.items.values_mut()
     }
 
     /// Iterator over items
     pub fn iter(&self) -> impl Iterator<Item = &ChatItem> {
-        self.items.iter()
+        self.items.values()
     }
 
     /// Direct access by index
     pub fn get(&self, idx: usize) -> Option<&ChatItem> {
-        self.items.get(idx)
+        self.items.get_index(idx).map(|(_, item)| item)
     }
 
     /// Direct mutable access by index
     pub fn get_mut(&mut self, idx: usize) -> Option<&mut ChatItem> {
-        self.items.get_mut(idx)
+        self.items.get_index_mut(idx).map(|(_, item)| item)
     }
 
     /// Get only message rows (filtering out meta rows)
     pub fn messages(&self) -> Vec<&MessageRow> {
         self.items
-            .iter()
+            .values()
             .filter_map(|item| {
                 if let ChatItem::Message(row) = item {
                     Some(row)
@@ -220,14 +312,14 @@ impl ChatStore {
     /// Check if there are any pending tool calls
     pub fn has_pending_tools(&self) -> bool {
         self.items
-            .iter()
+            .values()
             .any(|item| matches!(item, ChatItem::PendingToolCall { .. }))
     }
 
     /// Get user messages for edit history
     pub fn user_messages(&self) -> Vec<(usize, &MessageRow)> {
         self.items
-            .iter()
+            .values()
             .enumerate()
             .filter_map(|(idx, item)| {
                 if let ChatItem::Message(row) = item {
@@ -243,30 +335,50 @@ impl ChatStore {
             .collect()
     }
 
-    /// Rebuild the index after direct mutations
-    pub fn rebuild_index(&mut self) {
-        self.index.clear();
-        for (idx, item) in self.items.iter().enumerate() {
-            self.index.insert(item.id().to_string(), idx);
+    fn lookup(&self, id: &RowId) -> Option<ChatItemKey> {
+        self.id_to_key.get(id).copied()
+    }
+
+    /// Iterator for items that can be used without allocating
+    pub fn iter_items(&self) -> impl Iterator<Item = &ChatItem> + '_ {
+        self.items.values()
+    }
+
+    /// Find an item by predicate (useful for finding pending tools, operations, etc.)
+    pub fn find_item<F>(&self, predicate: F) -> Option<(ChatItemKey, &ChatItem)>
+    where
+        F: Fn(&ChatItem) -> bool,
+    {
+        self.items.iter().find_map(|(&key, item)| {
+            if predicate(item) {
+                Some((key, item))
+            } else {
+                None
+            }
+        })
+    }
+
+    /// Get pending tool call by ID
+    pub fn get_pending_tool_key(&self, tool_id: &str) -> Option<ChatItemKey> {
+        self.pending_tool_keys.get(tool_id).copied()
+    }
+
+    /// Remove pending tool call by ID
+    pub fn remove_pending_tool(&mut self, tool_id: &str) {
+        if let Some(key) = self.pending_tool_keys.get(tool_id).copied() {
+            self.remove_by_key(key);
         }
     }
 
-    fn lookup(&self, id: &RowId) -> Option<usize> {
-        self.index.get(id).copied()
+    /// Get in-flight operation by ID
+    pub fn get_in_flight_op_key(&self, operation_id: &Uuid) -> Option<ChatItemKey> {
+        self.in_flight_op_keys.get(operation_id).copied()
     }
-}
 
-// Vec-like convenience impls
-impl std::ops::Deref for ChatStore {
-    type Target = Vec<ChatItem>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.items
-    }
-}
-
-impl std::ops::DerefMut for ChatStore {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.items
+    /// Remove in-flight operation by ID
+    pub fn remove_in_flight_op(&mut self, operation_id: &Uuid) {
+        if let Some(key) = self.in_flight_op_keys.get(operation_id).copied() {
+            self.remove_by_key(key);
+        }
     }
 }

--- a/crates/conductor-tui/src/tui/state/view_model.rs
+++ b/crates/conductor-tui/src/tui/state/view_model.rs
@@ -53,8 +53,8 @@ impl MessageViewModel {
             }
         }
 
-        // Add the message and get its index
-        let message_index = self.chat_store.add_message(message.clone());
+        // Add the message
+        self.chat_store.add_message(message.clone());
 
         // For tool messages, set the message index in the registry
         if let Message::Tool { tool_use_id, .. } = &message {
@@ -69,8 +69,6 @@ impl MessageViewModel {
                     parameters: serde_json::Value::Null,
                 });
             self.tool_registry.register_call(tool_call);
-            self.tool_registry
-                .set_message_index(tool_use_id, message_index);
         }
     }
 
@@ -95,7 +93,7 @@ impl MessageViewModel {
             }
 
             // Add the message
-            let message_index = self.chat_store.add_message(message.clone());
+            self.chat_store.add_message(message.clone());
 
             // For tool messages, set the message index in the registry
             if let Message::Tool { tool_use_id, .. } = &message {
@@ -109,8 +107,6 @@ impl MessageViewModel {
                         parameters: serde_json::Value::Null,
                     });
                 self.tool_registry.register_call(tool_call);
-                self.tool_registry
-                    .set_message_index(tool_use_id, message_index);
             }
         }
 

--- a/crates/conductor-tui/src/tui/widgets/chat_list.rs
+++ b/crates/conductor-tui/src/tui/widgets/chat_list.rs
@@ -127,7 +127,7 @@ impl ChatListState {
 
 /// The ChatList widget
 pub struct ChatList<'a> {
-    items: &'a [ChatItem],
+    items: Vec<&'a ChatItem>,
     block: Option<Block<'a>>,
     hovered_message_id: Option<&'a str>,
     theme: &'a Theme,
@@ -135,7 +135,7 @@ pub struct ChatList<'a> {
 }
 
 impl<'a> ChatList<'a> {
-    pub fn new(items: &'a [ChatItem], theme: &'a Theme) -> Self {
+    pub fn new(items: Vec<&'a ChatItem>, theme: &'a Theme) -> Self {
         Self {
             items,
             block: None,

--- a/crates/conductor-tui/src/tui/widgets/input_panel.rs
+++ b/crates/conductor-tui/src/tui/widgets/input_panel.rs
@@ -308,9 +308,8 @@ impl InputPanelState {
     }
 
     /// Populate edit selection messages from chat store
-    pub fn populate_edit_selection(&mut self, chat_items: &[ChatItem]) {
+    pub fn populate_edit_selection<'a>(&mut self, chat_items: impl Iterator<Item = &'a ChatItem>) {
         self.edit_selection_messages = chat_items
-            .iter()
             .filter_map(|item| {
                 if let ChatItem::Message(row) = item {
                     if let Message::User { content, .. } = &row.inner {
@@ -935,7 +934,7 @@ mod tests {
             })),
         ];
 
-        state.populate_edit_selection(&chat_items);
+        state.populate_edit_selection(chat_items.iter());
 
         // Should have 2 user messages
         assert_eq!(state.edit_selection_messages.len(), 2);


### PR DESCRIPTION

- Introduce ChatItemKey for stable item identification
- Replace Vec<ChatItem> with IndexMap<ChatItemKey, ChatItem>
- Add dedicated lookup maps for pending tools and in-flight operations
- Decouple ToolRegistry from ChatStore's internal indices
- Improve API with key-based removal methods
- Eliminate index rebuilding and fragile position tracking