### PR TITLE
feat(tui): add custom slash command support

### DIFF
--- a/.conductor/commands.toml
+++ b/.conductor/commands.toml
@@ -1,0 +1,5 @@
+[[commands]]
+type = "prompt"
+name = "review"
+description = "Code review"
+prompt = "Review the changes for potential issues, omissions, or smells."

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1052,7 +1052,7 @@ dependencies = [
  "conductor-grpc",
  "conductor-proto",
  "conductor-tools",
- "dirs 6.0.0",
+ "directories",
  "fuzzy-matcher",
  "http 1.3.1",
  "indexmap 2.10.0",
@@ -1421,6 +1421,15 @@ dependencies = [
  "const-oid",
  "crypto-common",
  "subtle",
+]
+
+[[package]]
+name = "directories"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16f5094c54661b38d03bd7e50df373292118db60b585c08a411c6d840017fe7d"
+dependencies = [
+ "dirs-sys 0.5.0",
 ]
 
 [[package]]

--- a/crates/conductor-tui/Cargo.toml
+++ b/crates/conductor-tui/Cargo.toml
@@ -49,7 +49,6 @@ fuzzy-matcher = "0.3.7"
 regex = "1.11.1"
 process-wrap = { version = "8.2.1", features = ["tokio1"] }
 toml = "0.8.23"
-dirs = "6.0.0"
 pulldown-cmark = "0.9"
 itertools = "0.12"
 open = "5.0"
@@ -58,6 +57,7 @@ syntect = "5.2.0"
 strum = { version = "0.27.1", features = ["derive"] }
 strum_macros = "0.27.1"
 indexmap = { version = "2.0", features = ["std"] }
+directories = "6.0.0"
 
 [dev-dependencies]
 conductor-proto = { path = "../conductor-proto" }

--- a/crates/conductor-tui/src/tui/commands.rs
+++ b/crates/conductor-tui/src/tui/commands.rs
@@ -1,9 +1,10 @@
 pub mod registry;
 
+use crate::tui::custom_commands::CustomCommand;
 use conductor_core::app::conversation::{AppCommandType as CoreCommand, SlashCommandError};
 use std::fmt;
 use std::str::FromStr;
-use strum::{Display, EnumIter, EnumString, IntoEnumIterator};
+use strum::{Display, EnumIter, IntoEnumIterator};
 use thiserror::Error;
 
 /// Errors that can occur when parsing TUI commands
@@ -16,8 +17,7 @@ pub enum TuiCommandError {
 }
 
 /// TUI-specific commands that don't belong in the core
-#[derive(Debug, Clone, PartialEq, EnumString)]
-#[strum(serialize_all = "kebab-case")]
+#[derive(Debug, Clone, PartialEq)]
 pub enum TuiCommand {
     /// Reload files in the TUI
     ReloadFiles,
@@ -29,6 +29,8 @@ pub enum TuiCommand {
     Help(Option<String>),
     /// Switch editing mode
     EditingMode(Option<String>),
+    /// Custom user-defined command
+    Custom(CustomCommand),
 }
 
 /// Enum representing all TUI command types (without parameters)
@@ -191,6 +193,7 @@ impl TuiCommand {
             TuiCommand::EditingMode(Some(mode)) => {
                 format!("{} {}", TuiCommandType::EditingMode.command_name(), mode)
             }
+            TuiCommand::Custom(cmd) => cmd.name().to_string(),
         }
     }
 }
@@ -224,6 +227,8 @@ impl AppCommand {
             }
         }
 
+        // Note: Custom commands will be resolved by the caller using the registry
+        // since we can't access the registry from here
         Err(TuiCommandError::UnknownCommand(command.to_string()))
     }
 

--- a/crates/conductor-tui/src/tui/custom_commands.rs
+++ b/crates/conductor-tui/src/tui/custom_commands.rs
@@ -1,0 +1,289 @@
+use crate::tui::commands::{CoreCommandType, TuiCommandType};
+use directories::ProjectDirs;
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+use strum::IntoEnumIterator;
+use thiserror::Error;
+use tracing::{debug, warn};
+
+/// Errors that can occur with custom commands
+#[derive(Debug, Error)]
+pub enum CustomCommandError {
+    #[error("Failed to load custom commands config: {0}")]
+    ConfigLoadError(String),
+    #[error("Failed to parse custom commands config: {0}")]
+    ParseError(#[from] toml::de::Error),
+    #[error("IO error: {0}")]
+    IoError(#[from] std::io::Error),
+    #[error("Invalid command name '{0}': {1}")]
+    InvalidCommandName(String, String),
+    #[error("Command name '{0}' conflicts with built-in command")]
+    ConflictingCommandName(String),
+}
+
+/// Represents a custom command that can be dynamically loaded
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum CustomCommand {
+    /// A simple prompt command that sends predefined text
+    Prompt {
+        name: String,
+        description: String,
+        prompt: String,
+    },
+    // Future command types can be added here:
+    // Shell { name: String, description: String, command: String },
+    // Macro { name: String, description: String, steps: Vec<String> },
+}
+
+impl CustomCommand {
+    /// Get the name of the command
+    pub fn name(&self) -> &str {
+        match self {
+            CustomCommand::Prompt { name, .. } => name,
+        }
+    }
+
+    /// Get the description of the command
+    pub fn description(&self) -> &str {
+        match self {
+            CustomCommand::Prompt { description, .. } => description,
+        }
+    }
+
+    /// Validate the command configuration
+    pub fn validate(&self) -> Result<(), CustomCommandError> {
+        let name = self.name();
+
+        // Check for empty name
+        if name.is_empty() {
+            return Err(CustomCommandError::InvalidCommandName(
+                name.to_string(),
+                "Command name cannot be empty".to_string(),
+            ));
+        }
+
+        // Check for invalid characters
+        if name.contains('/') || name.contains(' ') {
+            return Err(CustomCommandError::InvalidCommandName(
+                name.to_string(),
+                "Command name cannot contain '/' or spaces".to_string(),
+            ));
+        }
+
+        // Check for conflicts with built-in commands
+        for cmd in TuiCommandType::iter() {
+            if cmd.command_name() == name {
+                return Err(CustomCommandError::ConflictingCommandName(name.to_string()));
+            }
+        }
+
+        for cmd in CoreCommandType::iter() {
+            if cmd.command_name() == name {
+                return Err(CustomCommandError::ConflictingCommandName(name.to_string()));
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// Configuration file structure for custom commands
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct CustomCommandsConfig {
+    #[serde(default)]
+    pub commands: Vec<CustomCommand>,
+}
+
+/// Get all paths where custom commands can be defined, in order of precedence
+pub fn get_config_paths() -> Vec<PathBuf> {
+    let mut paths = Vec::new();
+
+    // 1. Project-specific config (highest precedence)
+    paths.push(PathBuf::from(".conductor").join("commands.toml"));
+
+    // 2. User config directory (platform-specific)
+    if let Some(proj_dirs) = ProjectDirs::from("", "", "conductor") {
+        paths.push(proj_dirs.config_dir().join("commands.toml"));
+    }
+
+    paths
+}
+
+/// Get the path to the custom commands configuration file
+pub fn get_config_path() -> PathBuf {
+    // For backwards compatibility, return the first writable path
+    get_config_paths()
+        .into_iter()
+        .next()
+        .unwrap_or_else(|| PathBuf::from(".conductor").join("commands.toml"))
+}
+
+/// Load custom commands from the configuration file
+pub fn load_custom_commands() -> Result<Vec<CustomCommand>, CustomCommandError> {
+    let mut all_commands = Vec::new();
+    let mut seen_names = std::collections::HashSet::new();
+
+    // Load from all paths in order of precedence
+    for config_path in get_config_paths() {
+        debug!("Checking for custom commands at: {}", config_path.display());
+
+        if !config_path.exists() {
+            debug!("Config not found at {}", config_path.display());
+            continue;
+        }
+
+        let config_content = match std::fs::read_to_string(&config_path) {
+            Ok(content) => content,
+            Err(e) => {
+                warn!("Failed to read {}: {}", config_path.display(), e);
+                continue;
+            }
+        };
+
+        let config: CustomCommandsConfig = match toml::from_str(&config_content) {
+            Ok(config) => config,
+            Err(e) => {
+                warn!(
+                    "Failed to parse {}: {}. Skipping this config file.",
+                    config_path.display(),
+                    e
+                );
+                continue;
+            }
+        };
+
+        debug!(
+            "Found {} commands in {}",
+            config.commands.len(),
+            config_path.display()
+        );
+
+        // Check for duplicates within the same file
+        let mut file_names = std::collections::HashSet::new();
+        for cmd in &config.commands {
+            if !file_names.insert(cmd.name().to_string()) {
+                warn!(
+                    "Duplicate command '{}' found within {}. Skipping duplicates.",
+                    cmd.name(),
+                    config_path.display()
+                );
+            }
+        }
+
+        // Add commands, skipping duplicates (earlier paths take precedence)
+        for cmd in config.commands {
+            // Validate the command
+            match cmd.validate() {
+                Ok(()) => {
+                    if seen_names.insert(cmd.name().to_string()) {
+                        all_commands.push(cmd);
+                    } else {
+                        debug!(
+                            "Skipping duplicate command '{}' from {}",
+                            cmd.name(),
+                            config_path.display()
+                        );
+                    }
+                }
+                Err(e) => {
+                    warn!(
+                        "Skipping invalid command from {}: {}",
+                        config_path.display(),
+                        e
+                    );
+                }
+            }
+        }
+    }
+
+    debug!("Total custom commands loaded: {}", all_commands.len());
+    Ok(all_commands)
+}
+
+/// Save custom commands to the configuration file
+pub fn save_custom_commands(commands: &[CustomCommand]) -> Result<(), CustomCommandError> {
+    let config_path = get_config_path();
+
+    // Ensure parent directory exists
+    if let Some(parent) = config_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+
+    let config = CustomCommandsConfig {
+        commands: commands.to_vec(),
+    };
+
+    let config_content = toml::to_string_pretty(&config).map_err(|e| {
+        CustomCommandError::ConfigLoadError(format!("Failed to serialize config: {e}"))
+    })?;
+
+    std::fs::write(&config_path, config_content)?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn setup_test_config(content: &str) -> PathBuf {
+        let temp_dir = TempDir::new().unwrap();
+        let config_path = temp_dir.path().join("commands.toml");
+        fs::write(&config_path, content).unwrap();
+        config_path
+    }
+
+    #[test]
+    fn test_parse_prompt_command() {
+        let config_content = r#"
+[[commands]]
+type = "prompt"
+name = "standup"
+description = "Generate a standup report"
+prompt = "What did I work on today? Check git log and recent file changes."
+"#;
+
+        let config: CustomCommandsConfig = toml::from_str(config_content).unwrap();
+        assert_eq!(config.commands.len(), 1);
+
+        match &config.commands[0] {
+            CustomCommand::Prompt {
+                name,
+                description,
+                prompt,
+            } => {
+                assert_eq!(name, "standup");
+                assert_eq!(description, "Generate a standup report");
+                assert_eq!(
+                    prompt,
+                    "What did I work on today? Check git log and recent file changes."
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_multiple_commands() {
+        let config_content = r#"
+[[commands]]
+type = "prompt"
+name = "test"
+description = "Run tests"
+prompt = "Run the test suite and show me any failures"
+
+[[commands]]
+type = "prompt"
+name = "review"
+description = "Code review helper"
+prompt = "Review the recent changes and suggest improvements"
+"#;
+
+        let config: CustomCommandsConfig = toml::from_str(config_content).unwrap();
+        assert_eq!(config.commands.len(), 2);
+        assert_eq!(config.commands[0].name(), "test");
+        assert_eq!(config.commands[1].name(), "review");
+    }
+}

--- a/crates/conductor-tui/src/tui/theme/loader.rs
+++ b/crates/conductor-tui/src/tui/theme/loader.rs
@@ -1,6 +1,7 @@
 //! Theme loading functionality
 
 use super::{RawTheme, Theme, ThemeError};
+use directories::ProjectDirs;
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -56,14 +57,13 @@ impl ThemeLoader {
     pub fn new() -> Self {
         let mut search_paths = Vec::new();
 
-        // Add XDG config directory
-        if let Some(xdg_config) = dirs::config_dir() {
-            search_paths.push(xdg_config.join("conductor/themes"));
-        }
+        // Add paths from directories crate
+        if let Some(proj_dirs) = ProjectDirs::from("", "", "conductor") {
+            // Config directory (e.g., ~/.config/conductor/themes on Linux)
+            search_paths.push(proj_dirs.config_dir().join("themes"));
 
-        // Add home directory fallback
-        if let Some(home) = dirs::home_dir() {
-            search_paths.push(home.join(".config/conductor/themes"));
+            // Data directory as fallback (e.g., ~/.local/share/conductor/themes on Linux)
+            search_paths.push(proj_dirs.data_dir().join("themes"));
         }
 
         Self { search_paths }


### PR DESCRIPTION
and migrate to directories crate

Adds dynamic custom command loading from .conductor/commands.toml or user config directory. Includes validation, registry integration, prompt command execution, tests, and UI handling. Replaces deprecated ~/conductor/custom-prompts crate with  for config path resolution across modules.