### PR TITLE
chore: release v0.1.0

### DIFF
--- a/crates/conductor-cli/CHANGELOG.md
+++ b/crates/conductor-cli/CHANGELOG.md
@@ -1,0 +1,58 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/BrendanGraham14/conductor/releases/tag/conductor-cli-v0.1.0) - 2025-07-22
+
+### Added
+
+- add authentication setup flow and preferences management
+- add bash command approval patterns and refactor approval system
+- initial support for themes + some presets
+- support grok
+- support importing api keys to keyring
+- Introduce LlmConfigProvider and refactor config handling
+- anthropic oauth support
+- path as parameter to local workspace
+- support more mcp backends
+- default to opus
+- session config toml file support
+- add thread support for message editing and conversation branching
+- add configurable session database path
+
+### Fixed
+
+- limit
+- spawn notifications in a subprocess
+- clippy warnings
+- support latest session alias
+
+### Other
+
+- centralize workspace package metadata and dependencies
+- message into struct with enum as data
+- update reqwest
+- rustls
+- configure dist
+- drop thread_id and rely solely on parent_message_id ancestry
+- remove dead code
+- debug logs for config loading
+- limit sessions to 20
+- clean up dead code
+- Revert "chore: support tokio console subscriber"
+- support tokio console subscriber
+- various fixes for just ci
+- remove ratatui from cli
+- drop schema feature, just enable by default
+- just fix
+- improve error handling
+- some tidyup around tokio tasks
+- more strict workspace setup
+- clean up
+- update architecture, in_memory -> local_server
+- rename crates + move them under crates/

--- a/crates/conductor-core/CHANGELOG.md
+++ b/crates/conductor-core/CHANGELOG.md
@@ -1,0 +1,105 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/BrendanGraham14/conductor/releases/tag/conductor-core-v0.1.0) - 2025-07-22
+
+### Added
+
+- tweak o3 prompts, output tokens, enable gpt-4.1
+- implement non-destructive conversation branching and thread-aware compaction
+- *(tui)* add vim and simple editing modes
+- *(arch)* introduce conductor-workspace crate
+- *(model fzf)* filter weak models, boost aliases
+- fuzzy-find commands
+- Introduce unified operation tracking model
+- compact uses current model instead of hardcoded claude-3.7-sonnet
+- support grok-4
+- add authentication setup flow and preferences management
+- add bash command approval patterns and refactor approval system
+- support grok
+- cache system prompt
+- *(environment)* include some ignored paths (but no children), add a max_files and max_depth limit, breadth-first
+- support importing api keys to keyring
+- Introduce LlmConfigProvider and refactor config handling
+- anthropic oauth support
+- custom gemini prompt based on gemini-cli
+- *(nix)* add Nix development environment
+- path as parameter to local workspace
+- Refactor slash command parsing and handling
+- support more mcp backends
+- default to opus
+- initial mcp support
+- session config toml file support
+- add fzf-like fuzzy-finder support
+- add notification support to TUI
+- initial edit support
+- add thread support for message editing and conversation branching
+- add configurable session database path
+
+### Fixed
+
+- *(gemini+mcp)* filter out fields which aren't supported by gemini api (but are tolerated by other apis)
+- filter models for picker everywhere
+- don't omit dotfiles by default
+- some clean up on Processing handling to reduce unnecessary notifs
+- serialize creds to a single keyring, delete encrypted file storage
+- bug where tool message ids were getting regenerated incorrectly
+- gracefully skip directories if conductor does not have permission to access them
+- workspaceconfig::local
+- bug where app is re-created on resume
+- o4-mini alias
+- edit bugs
+- compilation errors after pulling
+- *(gemini)* handle malformed function call finish reason
+- pin rmcp
+- schema feature
+- replace blocking std::process::Command with git2 crate
+- don't use llm_format in tui
+- *(openai)* don't pass in thought content to request
+- don't pass thoughts in to gemini, it mimics the [thought] format if we do
+
+### Other
+
+- centralize workspace package metadata and dependencies
+- a bunch of tidyup around message lineage handling
+- message into struct with enum as data
+- small tidyup
+- break things into widgets
+- update reqwest
+- dead test
+- swap out git2 for gix
+- rustls
+- remove default git2 deps to remove dependency on openssl
+- drop thread_id and rely solely on parent_message_id ancestry
+- debug log for no content blocks error
+- centralize memory file name and add tool name constants
+- more verbose debug log
+- remove dead code
+- proto structure
+- clean up dead code
+- log events which fail to get broadcasted
+- grok -> xai
+- remove LlmConfig caching for immediate auth updates
+- decouple tool approval & execution callbacks
+- propagate / surface errors more clearly
+- default to warn
+- pull prompts into source code
+- various fixes for just ci
+- support debug logging messages
+- remove anyhow from tui
+- drop schema feature, just enable by default
+- just fix
+- improve error handling
+- some tidyup around tokio tasks
+- more strict workspace setup
+- log gemini request if 400/404
+- use well-typed outputs for tools
+- clean up
+- sessino manager: small cleanup
+- rename crates + move them under crates/

--- a/crates/conductor-grpc/CHANGELOG.md
+++ b/crates/conductor-grpc/CHANGELOG.md
@@ -1,0 +1,54 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/BrendanGraham14/conductor/releases/tag/conductor-grpc-v0.1.0) - 2025-07-22
+
+### Added
+
+- implement non-destructive conversation branching and thread-aware compaction
+- *(grpc)* implement streaming for large session state endpoints
+- *(arch)* introduce conductor-workspace crate
+- fuzzy-find commands
+- Introduce unified operation tracking model
+- add authentication setup flow and preferences management
+- add bash command approval patterns and refactor approval system
+- Introduce LlmConfigProvider and refactor config handling
+- anthropic oauth support
+- path as parameter to local workspace
+- Refactor slash command parsing and handling
+- support more mcp backends
+- initial mcp support
+- add fzf-like fuzzy-finder support
+- initial edit support
+- add thread support for message editing and conversation branching
+- add configurable session database path
+
+### Fixed
+
+- don't use llm_format in tui
+
+### Other
+
+- centralize workspace package metadata and dependencies
+- message into struct with enum as data
+- expose ActiveMessageIdChanged event
+- drop thread_id and rely solely on parent_message_id ancestry
+- formatting
+- remove dead code
+- proto structure
+- various fixes for just ci
+- just fix
+- improve error handling
+- some tidyup around tokio tasks
+- more strict workspace setup
+- use well-typed outputs for tools
+- clean up
+- sessino manager: small cleanup
+- update architecture, in_memory -> local_server
+- rename crates + move them under crates/

--- a/crates/conductor-macros/CHANGELOG.md
+++ b/crates/conductor-macros/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/BrendanGraham14/conductor/releases/tag/conductor-macros-v0.1.0) - 2025-07-22
+
+### Added
+
+- Introduce LlmConfigProvider and refactor config handling
+
+### Fixed
+
+- don't use llm_format in tui
+
+### Other
+
+- centralize workspace package metadata and dependencies
+- more strict workspace setup
+- use well-typed outputs for tools
+- rename crates + move them under crates/

--- a/crates/conductor-proto/CHANGELOG.md
+++ b/crates/conductor-proto/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/BrendanGraham14/conductor/releases/tag/conductor-proto-v0.1.0) - 2025-07-22
+
+### Added
+
+- add bash command approval patterns and refactor approval system
+- *(nix)* add Nix development environment
+
+### Other
+
+- centralize workspace package metadata and dependencies
+- proto structure
+- more strict workspace setup
+- rename crates + move them under crates/

--- a/crates/conductor-remote-workspace/CHANGELOG.md
+++ b/crates/conductor-remote-workspace/CHANGELOG.md
@@ -1,0 +1,38 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/BrendanGraham14/conductor/releases/tag/conductor-remote-workspace-v0.1.0) - 2025-07-22
+
+### Added
+
+- *(arch)* introduce conductor-workspace crate
+- initial mcp support
+- add fzf-like fuzzy-finder support
+
+### Fixed
+
+- don't omit dotfiles by default
+- replace blocking std::process::Command with git2 crate
+- don't use llm_format in tui
+
+### Other
+
+- centralize workspace package metadata and dependencies
+- swap out git2 for gix
+- remove default git2 deps to remove dependency on openssl
+- configure dist
+- proto structure
+- various fixes for just ci
+- remove anyhow from remote-workspace
+- just fix
+- some tidyup around tokio tasks
+- more strict workspace setup
+- use well-typed outputs for tools
+- clean up
+- rename crates + move them under crates/

--- a/crates/conductor-tools/CHANGELOG.md
+++ b/crates/conductor-tools/CHANGELOG.md
@@ -1,0 +1,31 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/BrendanGraham14/conductor/releases/tag/conductor-tools-v0.1.0) - 2025-07-22
+
+### Added
+
+- *(arch)* introduce conductor-workspace crate
+- async bash
+- initial mcp support
+
+### Fixed
+
+- don't use llm_format in tui
+
+### Other
+
+- centralize workspace package metadata and dependencies
+- update reqwest
+- rustls
+- propagate / surface errors more clearly
+- just fix
+- more strict workspace setup
+- use well-typed outputs for tools
+- rename crates + move them under crates/

--- a/crates/conductor-tui/CHANGELOG.md
+++ b/crates/conductor-tui/CHANGELOG.md
@@ -1,0 +1,127 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/BrendanGraham14/conductor/releases/tag/conductor-tui-v0.1.0) - 2025-07-22
+
+### Added
+
+- *(tui)* conversation branch filtering
+- add approval() view for tool calls, override it for edit
+- *(tui)* add custom slash command support and migrate to directories crate
+- *(tui)* add vim and simple editing modes
+- *(arch)* introduce conductor-workspace crate
+- *(model fzf)* filter weak models, boost aliases
+- fuzzy-finder for model picker & theme picker
+- fuzzy-find commands
+- richer nav / delete / etc keybinds
+- clarify approval copy
+- Introduce unified operation tracking model
+- wrap system notices
+- markdown code syntax highlighting
+- default to catppuccin-mocha
+- add authentication setup flow and preferences management
+- add bash command approval patterns and refactor approval system
+- *(markdown)* task lists
+- fork/vendor tui-markdown, support theming
+- initial support for themes + some presets
+- support alt+left/right
+- tweak input panel style
+- input panel styling improvements
+- Introduce LlmConfigProvider and refactor config handling
+- tool styling tweaks
+- path as parameter to local workspace
+- Refactor slash command parsing and handling
+- support more mcp backends
+- *(tui)* add ExternalFormatter for MCP tools and pretty JSON output
+- *(fzf)* add a space after selected path
+- styling
+- support tab to accept fzf suggestion
+- add fzf-like fuzzy-finder support
+- markdown support + render caching
+- dynamically sized input / tool approval area
+- add notification support to TUI
+- nicer message selection
+- initial edit support
+- add thread support for message editing and conversation branching
+
+### Fixed
+
+- padding for assistant & tool msgs
+- render bullet points onseparate lines in markdown lists
+- show tool name
+- *(vim mode / fzf)* make / in normal mode pop open fzf
+- fuzzy-finder
+- *(vim mode)* state transitions to setup
+- *(vim mode)* esc esc to clear & edit
+- filter models for picker everywhere
+- some clean up on Processing handling to reduce unnecessary notifs
+- markdown lists with formatted text
+- centralize auth controller creation in setup handler
+- clear auth controller after entering creds
+- markdown codeblock handling
+- clear in_list_item_start state for empty list items
+- markdown overflow
+- rebase error
+- straggling task
+- spawn notifications in a subprocess
+- clippy warnings
+- edit bugs
+- *(tui)* wrap desktop notifications in spawn_blocking to avoid blocking async runtime
+- *(fzf)* don't override textarea scrolling
+- fzf passing up/down through to textarea when unhandled
+- fzf scroll direction after inverting
+- tui cleanup in tests
+- a few fzf bugs
+- make edit selection a stateful widget
+- trim command
+- don't truncate bash command
+- don't use llm_format in tui
+- render full command output
+- casing
+- display tool status, tidy up formatting
+- scroll by 1
+- tool approval action key styling
+- overflow
+- support paste in bash mode
+
+### Other
+
+- centralize workspace package metadata and dependencies
+- a bunch of tidyup around message lineage handling
+- message into struct with enum as data
+- widgets now only expose lines(), chat viewport renders
+- small tidyup
+- borrow chatitems
+- break things into widgets
+- drop thread_id and rely solely on parent_message_id ancestry
+- replace vec-based ChatStore with IndexMap for stable key-based access
+- proto structure
+- don't log info about cancellation
+- grok -> xai
+- propagate / surface errors more clearly
+- better keybindings
+- more cleanup
+- *(tui)* use tokio::time::interval for spinner animation
+- various fixes for just ci
+- remove anyhow from tui
+- remove direct crossterm dep
+- just fix
+- *(tui)* replace actually_beep with notify-rust's native sound support
+- improve error handling
+- more strict workspace setup
+- fzf helpers
+- pull input panel and status bar into widgets, pull tui keystroke handlers into separate files
+- pull out input_panel rendering function
+- dead code
+- unify caching for chat items
+- use well-typed outputs for tools
+- clean up
+- add edit to copy
+- add hover indicator for message to edit
+- rename crates + move them under crates/

--- a/crates/conductor-workspace-client/CHANGELOG.md
+++ b/crates/conductor-workspace-client/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/BrendanGraham14/conductor/releases/tag/conductor-workspace-client-v0.1.0) - 2025-07-22
+
+### Added
+
+- *(arch)* introduce conductor-workspace crate
+
+### Other
+
+- centralize workspace package metadata and dependencies

--- a/crates/conductor-workspace/CHANGELOG.md
+++ b/crates/conductor-workspace/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/BrendanGraham14/conductor/releases/tag/conductor-workspace-v0.1.0) - 2025-07-22
+
+### Added
+
+- *(arch)* introduce conductor-workspace crate
+
+### Other
+
+- centralize workspace package metadata and dependencies
+- small tidyup
+- swap out git2 for gix


### PR DESCRIPTION



## 🤖 New release

* `conductor-macros`: 0.1.0
* `conductor-proto`: 0.1.0
* `conductor-tools`: 0.1.0
* `conductor-workspace`: 0.1.0
* `conductor-workspace-client`: 0.1.0
* `conductor-core`: 0.1.0
* `conductor-grpc`: 0.1.0
* `conductor-tui`: 0.1.0
* `conductor-cli`: 0.1.0
* `conductor-remote-workspace`: 0.1.0

<details><summary><i><b>Changelog</b></i></summary><p>

## `conductor-macros`

<blockquote>

## [0.1.0](https://github.com/BrendanGraham14/conductor/releases/tag/conductor-macros-v0.1.0) - 2025-07-22

### Added

- Introduce LlmConfigProvider and refactor config handling

### Fixed

- don't use llm_format in tui

### Other

- centralize workspace package metadata and dependencies
- more strict workspace setup
- use well-typed outputs for tools
- rename crates + move them under crates/
</blockquote>

## `conductor-proto`

<blockquote>

## [0.1.0](https://github.com/BrendanGraham14/conductor/releases/tag/conductor-proto-v0.1.0) - 2025-07-22

### Added

- add bash command approval patterns and refactor approval system
- *(nix)* add Nix development environment

### Other

- centralize workspace package metadata and dependencies
- proto structure
- more strict workspace setup
- rename crates + move them under crates/
</blockquote>

## `conductor-tools`

<blockquote>

## [0.1.0](https://github.com/BrendanGraham14/conductor/releases/tag/conductor-tools-v0.1.0) - 2025-07-22

### Added

- *(arch)* introduce conductor-workspace crate
- async bash
- initial mcp support

### Fixed

- don't use llm_format in tui

### Other

- centralize workspace package metadata and dependencies
- update reqwest
- rustls
- propagate / surface errors more clearly
- just fix
- more strict workspace setup
- use well-typed outputs for tools
- rename crates + move them under crates/
</blockquote>

## `conductor-workspace`

<blockquote>

## [0.1.0](https://github.com/BrendanGraham14/conductor/releases/tag/conductor-workspace-v0.1.0) - 2025-07-22

### Added

- *(arch)* introduce conductor-workspace crate

### Other

- centralize workspace package metadata and dependencies
- small tidyup
- swap out git2 for gix
</blockquote>

## `conductor-workspace-client`

<blockquote>

## [0.1.0](https://github.com/BrendanGraham14/conductor/releases/tag/conductor-workspace-client-v0.1.0) - 2025-07-22

### Added

- *(arch)* introduce conductor-workspace crate

### Other

- centralize workspace package metadata and dependencies
</blockquote>

## `conductor-core`

<blockquote>

## [0.1.0](https://github.com/BrendanGraham14/conductor/releases/tag/conductor-core-v0.1.0) - 2025-07-22

### Added

- tweak o3 prompts, output tokens, enable gpt-4.1
- implement non-destructive conversation branching and thread-aware compaction
- *(tui)* add vim and simple editing modes
- *(arch)* introduce conductor-workspace crate
- *(model fzf)* filter weak models, boost aliases
- fuzzy-find commands
- Introduce unified operation tracking model
- compact uses current model instead of hardcoded claude-3.7-sonnet
- support grok-4
- add authentication setup flow and preferences management
- add bash command approval patterns and refactor approval system
- support grok
- cache system prompt
- *(environment)* include some ignored paths (but no children), add a max_files and max_depth limit, breadth-first
- support importing api keys to keyring
- Introduce LlmConfigProvider and refactor config handling
- anthropic oauth support
- custom gemini prompt based on gemini-cli
- *(nix)* add Nix development environment
- path as parameter to local workspace
- Refactor slash command parsing and handling
- support more mcp backends
- default to opus
- initial mcp support
- session config toml file support
- add fzf-like fuzzy-finder support
- add notification support to TUI
- initial edit support
- add thread support for message editing and conversation branching
- add configurable session database path

### Fixed

- *(gemini+mcp)* filter out fields which aren't supported by gemini api (but are tolerated by other apis)
- filter models for picker everywhere
- don't omit dotfiles by default
- some clean up on Processing handling to reduce unnecessary notifs
- serialize creds to a single keyring, delete encrypted file storage
- bug where tool message ids were getting regenerated incorrectly
- gracefully skip directories if conductor does not have permission to access them
- workspaceconfig::local
- bug where app is re-created on resume
- o4-mini alias
- edit bugs
- compilation errors after pulling
- *(gemini)* handle malformed function call finish reason
- pin rmcp
- schema feature
- replace blocking std::process::Command with git2 crate
- don't use llm_format in tui
- *(openai)* don't pass in thought content to request
- don't pass thoughts in to gemini, it mimics the [thought] format if we do

### Other

- centralize workspace package metadata and dependencies
- a bunch of tidyup around message lineage handling
- message into struct with enum as data
- small tidyup
- break things into widgets
- update reqwest
- dead test
- swap out git2 for gix
- rustls
- remove default git2 deps to remove dependency on openssl
- drop thread_id and rely solely on parent_message_id ancestry
- debug log for no content blocks error
- centralize memory file name and add tool name constants
- more verbose debug log
- remove dead code
- proto structure
- clean up dead code
- log events which fail to get broadcasted
- grok -> xai
- remove LlmConfig caching for immediate auth updates
- decouple tool approval & execution callbacks
- propagate / surface errors more clearly
- default to warn
- pull prompts into source code
- various fixes for just ci
- support debug logging messages
- remove anyhow from tui
- drop schema feature, just enable by default
- just fix
- improve error handling
- some tidyup around tokio tasks
- more strict workspace setup
- log gemini request if 400/404
- use well-typed outputs for tools
- clean up
- sessino manager: small cleanup
- rename crates + move them under crates/
</blockquote>

## `conductor-grpc`

<blockquote>

## [0.1.0](https://github.com/BrendanGraham14/conductor/releases/tag/conductor-grpc-v0.1.0) - 2025-07-22

### Added

- implement non-destructive conversation branching and thread-aware compaction
- *(grpc)* implement streaming for large session state endpoints
- *(arch)* introduce conductor-workspace crate
- fuzzy-find commands
- Introduce unified operation tracking model
- add authentication setup flow and preferences management
- add bash command approval patterns and refactor approval system
- Introduce LlmConfigProvider and refactor config handling
- anthropic oauth support
- path as parameter to local workspace
- Refactor slash command parsing and handling
- support more mcp backends
- initial mcp support
- add fzf-like fuzzy-finder support
- initial edit support
- add thread support for message editing and conversation branching
- add configurable session database path

### Fixed

- don't use llm_format in tui

### Other

- centralize workspace package metadata and dependencies
- message into struct with enum as data
- expose ActiveMessageIdChanged event
- drop thread_id and rely solely on parent_message_id ancestry
- formatting
- remove dead code
- proto structure
- various fixes for just ci
- just fix
- improve error handling
- some tidyup around tokio tasks
- more strict workspace setup
- use well-typed outputs for tools
- clean up
- sessino manager: small cleanup
- update architecture, in_memory -> local_server
- rename crates + move them under crates/
</blockquote>

## `conductor-tui`

<blockquote>

## [0.1.0](https://github.com/BrendanGraham14/conductor/releases/tag/conductor-tui-v0.1.0) - 2025-07-22

### Added

- *(tui)* conversation branch filtering
- add approval() view for tool calls, override it for edit
- *(tui)* add custom slash command support and migrate to directories crate
- *(tui)* add vim and simple editing modes
- *(arch)* introduce conductor-workspace crate
- *(model fzf)* filter weak models, boost aliases
- fuzzy-finder for model picker & theme picker
- fuzzy-find commands
- richer nav / delete / etc keybinds
- clarify approval copy
- Introduce unified operation tracking model
- wrap system notices
- markdown code syntax highlighting
- default to catppuccin-mocha
- add authentication setup flow and preferences management
- add bash command approval patterns and refactor approval system
- *(markdown)* task lists
- fork/vendor tui-markdown, support theming
- initial support for themes + some presets
- support alt+left/right
- tweak input panel style
- input panel styling improvements
- Introduce LlmConfigProvider and refactor config handling
- tool styling tweaks
- path as parameter to local workspace
- Refactor slash command parsing and handling
- support more mcp backends
- *(tui)* add ExternalFormatter for MCP tools and pretty JSON output
- *(fzf)* add a space after selected path
- styling
- support tab to accept fzf suggestion
- add fzf-like fuzzy-finder support
- markdown support + render caching
- dynamically sized input / tool approval area
- add notification support to TUI
- nicer message selection
- initial edit support
- add thread support for message editing and conversation branching

### Fixed

- padding for assistant & tool msgs
- render bullet points onseparate lines in markdown lists
- show tool name
- *(vim mode / fzf)* make / in normal mode pop open fzf
- fuzzy-finder
- *(vim mode)* state transitions to setup
- *(vim mode)* esc esc to clear & edit
- filter models for picker everywhere
- some clean up on Processing handling to reduce unnecessary notifs
- markdown lists with formatted text
- centralize auth controller creation in setup handler
- clear auth controller after entering creds
- markdown codeblock handling
- clear in_list_item_start state for empty list items
- markdown overflow
- rebase error
- straggling task
- spawn notifications in a subprocess
- clippy warnings
- edit bugs
- *(tui)* wrap desktop notifications in spawn_blocking to avoid blocking async runtime
- *(fzf)* don't override textarea scrolling
- fzf passing up/down through to textarea when unhandled
- fzf scroll direction after inverting
- tui cleanup in tests
- a few fzf bugs
- make edit selection a stateful widget
- trim command
- don't truncate bash command
- don't use llm_format in tui
- render full command output
- casing
- display tool status, tidy up formatting
- scroll by 1
- tool approval action key styling
- overflow
- support paste in bash mode

### Other

- centralize workspace package metadata and dependencies
- a bunch of tidyup around message lineage handling
- message into struct with enum as data
- widgets now only expose lines(), chat viewport renders
- small tidyup
- borrow chatitems
- break things into widgets
- drop thread_id and rely solely on parent_message_id ancestry
- replace vec-based ChatStore with IndexMap for stable key-based access
- proto structure
- don't log info about cancellation
- grok -> xai
- propagate / surface errors more clearly
- better keybindings
- more cleanup
- *(tui)* use tokio::time::interval for spinner animation
- various fixes for just ci
- remove anyhow from tui
- remove direct crossterm dep
- just fix
- *(tui)* replace actually_beep with notify-rust's native sound support
- improve error handling
- more strict workspace setup
- fzf helpers
- pull input panel and status bar into widgets, pull tui keystroke handlers into separate files
- pull out input_panel rendering function
- dead code
- unify caching for chat items
- use well-typed outputs for tools
- clean up
- add edit to copy
- add hover indicator for message to edit
- rename crates + move them under crates/
</blockquote>

## `conductor-cli`

<blockquote>

## [0.1.0](https://github.com/BrendanGraham14/conductor/releases/tag/conductor-cli-v0.1.0) - 2025-07-22

### Added

- add authentication setup flow and preferences management
- add bash command approval patterns and refactor approval system
- initial support for themes + some presets
- support grok
- support importing api keys to keyring
- Introduce LlmConfigProvider and refactor config handling
- anthropic oauth support
- path as parameter to local workspace
- support more mcp backends
- default to opus
- session config toml file support
- add thread support for message editing and conversation branching
- add configurable session database path

### Fixed

- limit
- spawn notifications in a subprocess
- clippy warnings
- support latest session alias

### Other

- centralize workspace package metadata and dependencies
- message into struct with enum as data
- update reqwest
- rustls
- configure dist
- drop thread_id and rely solely on parent_message_id ancestry
- remove dead code
- debug logs for config loading
- limit sessions to 20
- clean up dead code
- Revert "chore: support tokio console subscriber"
- support tokio console subscriber
- various fixes for just ci
- remove ratatui from cli
- drop schema feature, just enable by default
- just fix
- improve error handling
- some tidyup around tokio tasks
- more strict workspace setup
- clean up
- update architecture, in_memory -> local_server
- rename crates + move them under crates/
</blockquote>

## `conductor-remote-workspace`

<blockquote>

## [0.1.0](https://github.com/BrendanGraham14/conductor/releases/tag/conductor-remote-workspace-v0.1.0) - 2025-07-22

### Added

- *(arch)* introduce conductor-workspace crate
- initial mcp support
- add fzf-like fuzzy-finder support

### Fixed

- don't omit dotfiles by default
- replace blocking std::process::Command with git2 crate
- don't use llm_format in tui

### Other

- centralize workspace package metadata and dependencies
- swap out git2 for gix
- remove default git2 deps to remove dependency on openssl
- configure dist
- proto structure
- various fixes for just ci
- remove anyhow from remote-workspace
- just fix
- some tidyup around tokio tasks
- more strict workspace setup
- use well-typed outputs for tools
- clean up
- rename crates + move them under crates/
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).