### PR TITLE
chore: release v0.1.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5057,7 +5057,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "steer"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5122,7 +5122,7 @@ dependencies = [
 
 [[package]]
 name = "steer-core"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "aes-gcm",
  "async-stream",
@@ -5191,7 +5191,7 @@ dependencies = [
 
 [[package]]
 name = "steer-grpc"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5216,7 +5216,7 @@ dependencies = [
 
 [[package]]
 name = "steer-macros"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5226,7 +5226,7 @@ dependencies = [
 
 [[package]]
 name = "steer-proto"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "prost",
  "prost-types",
@@ -5236,7 +5236,7 @@ dependencies = [
 
 [[package]]
 name = "steer-remote-workspace"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "clap",
  "fuzzy-matcher",
@@ -5259,7 +5259,7 @@ dependencies = [
 
 [[package]]
 name = "steer-tools"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "ast-grep-core",
  "ast-grep-language",
@@ -5290,7 +5290,7 @@ dependencies = [
 
 [[package]]
 name = "steer-tui"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5338,7 +5338,7 @@ dependencies = [
 
 [[package]]
 name = "steer-workspace"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5362,7 +5362,7 @@ dependencies = [
 
 [[package]]
 name = "steer-workspace-client"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "async-trait",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,23 +3,23 @@ members = ["crates/*"]
 resolver = "3"
 
 [workspace.package]
-version = "0.1.6"
+version = "0.1.7"
 authors = ["Brendan Graham <brendanigraham@gmail.com>"]
 edition = "2024"
 license = "AGPL-3.0-or-later"
 repository = "https://github.com/brendangraham14/steer"
 
 [workspace.dependencies]
-steer = { version = "0.1.5", path = "crates/steer" }
-steer-core = { version = "0.1.5", path = "crates/steer-core" }
-steer-grpc = { version = "0.1.5", path = "crates/steer-grpc" }
-steer-macros = { version = "0.1.5", path = "crates/steer-macros" }
-steer-proto = { version = "0.1.5", path = "crates/steer-proto" }
-steer-remote-workspace = { version = "0.1.5", path = "crates/steer-remote-workspace" }
-steer-tools = { version = "0.1.5", path = "crates/steer-tools" }
-steer-tui = { version = "0.1.5", path = "crates/steer-tui" }
-steer-workspace = { version = "0.1.5", path = "crates/steer-workspace" }
-steer-workspace-client = { version = "0.1.5", path = "crates/steer-workspace-client" }
+steer = { version = "0.1.7", path = "crates/steer" }
+steer-core = { version = "0.1.7", path = "crates/steer-core" }
+steer-grpc = { version = "0.1.7", path = "crates/steer-grpc" }
+steer-macros = { version = "0.1.7", path = "crates/steer-macros" }
+steer-proto = { version = "0.1.7", path = "crates/steer-proto" }
+steer-remote-workspace = { version = "0.1.7", path = "crates/steer-remote-workspace" }
+steer-tools = { version = "0.1.7", path = "crates/steer-tools" }
+steer-tui = { version = "0.1.7", path = "crates/steer-tui" }
+steer-workspace = { version = "0.1.7", path = "crates/steer-workspace" }
+steer-workspace-client = { version = "0.1.7", path = "crates/steer-workspace-client" }
 
 [workspace.lints.rust]
 unused_must_use = "deny"

--- a/crates/steer-core/CHANGELOG.md
+++ b/crates/steer-core/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]

--- a/crates/steer-grpc/CHANGELOG.md
+++ b/crates/steer-grpc/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]

--- a/crates/steer-macros/CHANGELOG.md
+++ b/crates/steer-macros/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]

--- a/crates/steer-proto/CHANGELOG.md
+++ b/crates/steer-proto/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]

--- a/crates/steer-remote-workspace/CHANGELOG.md
+++ b/crates/steer-remote-workspace/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]

--- a/crates/steer-tools/CHANGELOG.md
+++ b/crates/steer-tools/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]

--- a/crates/steer-tui/CHANGELOG.md
+++ b/crates/steer-tui/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.7](https://github.com/BrendanGraham14/steer/compare/steer-tui-v0.1.6...steer-tui-v0.1.7) - 2025-07-23
+
+### Other
+
+- update Cargo.toml dependencies

--- a/crates/steer-workspace-client/CHANGELOG.md
+++ b/crates/steer-workspace-client/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]

--- a/crates/steer-workspace/CHANGELOG.md
+++ b/crates/steer-workspace/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]

--- a/crates/steer/CHANGELOG.md
+++ b/crates/steer/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]


### PR DESCRIPTION



## 🤖 New release

* `steer-macros`: 0.1.6 -> 0.1.7
* `steer-proto`: 0.1.6 -> 0.1.7
* `steer-tools`: 0.1.6 -> 0.1.7
* `steer-workspace`: 0.1.6 -> 0.1.7
* `steer-workspace-client`: 0.1.6 -> 0.1.7
* `steer-core`: 0.1.6 -> 0.1.7
* `steer-grpc`: 0.1.6 -> 0.1.7
* `steer-tui`: 0.1.6 -> 0.1.7 (✓ API compatible changes)
* `steer`: 0.1.6 -> 0.1.7
* `steer-remote-workspace`: 0.1.6 -> 0.1.7

<details><summary><i><b>Changelog</b></i></summary><p>








## `steer-tui`

<blockquote>

## [0.1.7](https://github.com/BrendanGraham14/steer/compare/steer-tui-v0.1.6...steer-tui-v0.1.7) - 2025-07-23

### Other

- update Cargo.toml dependencies
</blockquote>




</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).