### PR TITLE
chore: release v0.1.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5064,7 +5064,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "steer"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5129,7 +5129,7 @@ dependencies = [
 
 [[package]]
 name = "steer-core"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "aes-gcm",
  "async-stream",
@@ -5198,7 +5198,7 @@ dependencies = [
 
 [[package]]
 name = "steer-grpc"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5223,7 +5223,7 @@ dependencies = [
 
 [[package]]
 name = "steer-macros"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5233,7 +5233,7 @@ dependencies = [
 
 [[package]]
 name = "steer-proto"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "prost",
  "prost-types",
@@ -5243,7 +5243,7 @@ dependencies = [
 
 [[package]]
 name = "steer-remote-workspace"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "clap",
  "fuzzy-matcher",
@@ -5266,7 +5266,7 @@ dependencies = [
 
 [[package]]
 name = "steer-tools"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "ast-grep-core",
  "ast-grep-language",
@@ -5298,7 +5298,7 @@ dependencies = [
 
 [[package]]
 name = "steer-tui"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5346,7 +5346,7 @@ dependencies = [
 
 [[package]]
 name = "steer-workspace"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5370,7 +5370,7 @@ dependencies = [
 
 [[package]]
 name = "steer-workspace-client"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "async-trait",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,23 +3,23 @@ members = ["crates/*"]
 resolver = "3"
 
 [workspace.package]
-version = "0.1.11"
+version = "0.1.12"
 authors = ["Brendan Graham <brendanigraham@gmail.com>"]
 edition = "2024"
 license = "AGPL-3.0-or-later"
 repository = "https://github.com/brendangraham14/steer"
 
 [workspace.dependencies]
-steer = { version = "0.1.11", path = "crates/steer" }
-steer-core = { version = "0.1.11", path = "crates/steer-core" }
-steer-grpc = { version = "0.1.11", path = "crates/steer-grpc" }
-steer-macros = { version = "0.1.11", path = "crates/steer-macros" }
-steer-proto = { version = "0.1.11", path = "crates/steer-proto" }
-steer-remote-workspace = { version = "0.1.11", path = "crates/steer-remote-workspace" }
-steer-tools = { version = "0.1.11", path = "crates/steer-tools" }
-steer-tui = { version = "0.1.11", path = "crates/steer-tui" }
-steer-workspace = { version = "0.1.11", path = "crates/steer-workspace" }
-steer-workspace-client = { version = "0.1.11", path = "crates/steer-workspace-client" }
+steer = { version = "0.1.12", path = "crates/steer" }
+steer-core = { version = "0.1.12", path = "crates/steer-core" }
+steer-grpc = { version = "0.1.12", path = "crates/steer-grpc" }
+steer-macros = { version = "0.1.12", path = "crates/steer-macros" }
+steer-proto = { version = "0.1.12", path = "crates/steer-proto" }
+steer-remote-workspace = { version = "0.1.12", path = "crates/steer-remote-workspace" }
+steer-tools = { version = "0.1.12", path = "crates/steer-tools" }
+steer-tui = { version = "0.1.12", path = "crates/steer-tui" }
+steer-workspace = { version = "0.1.12", path = "crates/steer-workspace" }
+steer-workspace-client = { version = "0.1.12", path = "crates/steer-workspace-client" }
 
 [workspace.lints.rust]
 unused_must_use = "deny"

--- a/crates/steer/CHANGELOG.md
+++ b/crates/steer/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.12](https://github.com/BrendanGraham14/steer/compare/steer-v0.1.11...steer-v0.1.12) - 2025-07-25
+
+### Other
+
+- update Cargo.lock dependencies
+
 ## [0.1.10](https://github.com/BrendanGraham14/steer/compare/steer-v0.1.9...steer-v0.1.10) - 2025-07-24
 
 ### Other


### PR DESCRIPTION



## 🤖 New release

* `steer-macros`: 0.1.11 -> 0.1.12
* `steer-proto`: 0.1.11 -> 0.1.12
* `steer-tools`: 0.1.11 -> 0.1.12
* `steer-workspace`: 0.1.11 -> 0.1.12
* `steer-workspace-client`: 0.1.11 -> 0.1.12
* `steer-core`: 0.1.11 -> 0.1.12
* `steer-grpc`: 0.1.11 -> 0.1.12
* `steer-tui`: 0.1.11 -> 0.1.12
* `steer`: 0.1.11 -> 0.1.12 (✓ API compatible changes)
* `steer-remote-workspace`: 0.1.11 -> 0.1.12

<details><summary><i><b>Changelog</b></i></summary><p>


## `steer-proto`

<blockquote>

## [0.1.8](https://github.com/BrendanGraham14/steer/compare/steer-proto-v0.1.7...steer-proto-v0.1.8) - 2025-07-24

### Added

- mcp status tracking + some tool refactoring
- *(tui)* always use detailed view of todos
</blockquote>

## `steer-tools`

<blockquote>

## [0.1.8](https://github.com/BrendanGraham14/steer/compare/steer-tools-v0.1.7...steer-tools-v0.1.8) - 2025-07-24

### Added

- mcp status tracking + some tool refactoring
- *(tui)* unify/tidy todo formatting
- *(tui)* always use detailed view of todos

### Fixed

- *(bash tool)* limit {stdout|stderr} {chars|lines}

### Other

- a few more renames
</blockquote>

## `steer-workspace`

<blockquote>

## [0.1.11](https://github.com/BrendanGraham14/steer/compare/steer-workspace-v0.1.10...steer-workspace-v0.1.11) - 2025-07-25

### Added

- filter out .git from workspace file listing
</blockquote>

## `steer-workspace-client`

<blockquote>

## [0.1.8](https://github.com/BrendanGraham14/steer/compare/steer-workspace-client-v0.1.7...steer-workspace-client-v0.1.8) - 2025-07-24

### Added

- *(tui)* always use detailed view of todos
</blockquote>

## `steer-core`

<blockquote>

## [0.1.8](https://github.com/BrendanGraham14/steer/compare/steer-core-v0.1.7...steer-core-v0.1.8) - 2025-07-24

### Added

- mcp status tracking + some tool refactoring

### Other

- dead code
</blockquote>

## `steer-grpc`

<blockquote>

## [0.1.8](https://github.com/BrendanGraham14/steer/compare/steer-grpc-v0.1.7...steer-grpc-v0.1.8) - 2025-07-24

### Added

- mcp status tracking + some tool refactoring
- *(tui)* always use detailed view of todos

### Other

- simplify tui by passing grpc client in directly
- dead code
</blockquote>

## `steer-tui`

<blockquote>

## [0.1.9](https://github.com/BrendanGraham14/steer/compare/steer-tui-v0.1.8...steer-tui-v0.1.9) - 2025-07-24

### Added

- better diff display
</blockquote>

## `steer`

<blockquote>

## [0.1.12](https://github.com/BrendanGraham14/steer/compare/steer-v0.1.11...steer-v0.1.12) - 2025-07-25

### Other

- update Cargo.lock dependencies
</blockquote>

## `steer-remote-workspace`

<blockquote>

## [0.1.8](https://github.com/BrendanGraham14/steer/compare/steer-remote-workspace-v0.1.7...steer-remote-workspace-v0.1.8) - 2025-07-24

### Added

- mcp status tracking + some tool refactoring
- *(tui)* always use detailed view of todos
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).