### PR TITLE
chore: release v0.1.16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1212,9 +1212,9 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dyn-clone"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c7a8fb8a9fbf66c1f703fe16184d10ca0ee9d23be5b4436400408ba54a95005"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "either"
@@ -3019,16 +3019,17 @@ dependencies = [
 
 [[package]]
 name = "keyring"
-version = "3.6.2"
+version = "3.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1961983669d57bdfe6c0f3ef8e4c229b5ef751afcc7d87e4271d2f71f6ccfa8b"
+checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
 dependencies = [
  "byteorder",
  "linux-keyutils",
  "log",
  "security-framework 2.11.1",
  "security-framework 3.2.0",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
+ "zeroize",
 ]
 
 [[package]]
@@ -3128,9 +3129,9 @@ checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
 name = "litrs"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ce301924b7887e9d637144fdade93f9dfff9b60981d4ac161db09720d39aa5"
+checksum = "f5e54036fe321fd421e10d732f155734c4e4afd610dd556d9a82833ab3ee0bed"
 
 [[package]]
 name = "lock_api"
@@ -4079,9 +4080,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.15"
+version = "0.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e8af0dde094006011e6a740d4879319439489813bd0bcdc7d821beaeeff48ec"
+checksum = "7251471db004e509f4e75a62cca9435365b5ec7bcdff530d612ac7c87c44a792"
 dependencies = [
  "bitflags 2.9.1",
 ]
@@ -4382,9 +4383,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.25"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f"
+checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
 
 [[package]]
 name = "rustc-hash"
@@ -4429,9 +4430,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.29"
+version = "0.23.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2491382039b29b9b11ff08b76ff6c97cf287671dbb74f0be44bda389fffe9bd1"
+checksum = "069a8df149a16b1a12dcc31497c3396a173844be3cac4bd40c9e7671fef96671"
 dependencies = [
  "log",
  "once_cell",
@@ -5064,7 +5065,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "steer"
-version = "0.1.15"
+version = "0.1.16"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5129,7 +5130,7 @@ dependencies = [
 
 [[package]]
 name = "steer-core"
-version = "0.1.15"
+version = "0.1.16"
 dependencies = [
  "aes-gcm",
  "async-stream",
@@ -5198,7 +5199,7 @@ dependencies = [
 
 [[package]]
 name = "steer-grpc"
-version = "0.1.15"
+version = "0.1.16"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5223,7 +5224,7 @@ dependencies = [
 
 [[package]]
 name = "steer-macros"
-version = "0.1.15"
+version = "0.1.16"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5233,7 +5234,7 @@ dependencies = [
 
 [[package]]
 name = "steer-proto"
-version = "0.1.15"
+version = "0.1.16"
 dependencies = [
  "prost",
  "prost-types",
@@ -5243,7 +5244,7 @@ dependencies = [
 
 [[package]]
 name = "steer-remote-workspace"
-version = "0.1.15"
+version = "0.1.16"
 dependencies = [
  "clap",
  "fuzzy-matcher",
@@ -5266,7 +5267,7 @@ dependencies = [
 
 [[package]]
 name = "steer-tools"
-version = "0.1.15"
+version = "0.1.16"
 dependencies = [
  "ast-grep-core",
  "ast-grep-language",
@@ -5298,7 +5299,7 @@ dependencies = [
 
 [[package]]
 name = "steer-tui"
-version = "0.1.15"
+version = "0.1.16"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5346,7 +5347,7 @@ dependencies = [
 
 [[package]]
 name = "steer-workspace"
-version = "0.1.15"
+version = "0.1.16"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5370,7 +5371,7 @@ dependencies = [
 
 [[package]]
 name = "steer-workspace-client"
-version = "0.1.15"
+version = "0.1.16"
 dependencies = [
  "async-trait",
  "serde",
@@ -5652,9 +5653,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.46.1"
+version = "1.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc3a2344dafbe23a245241fe8b09735b521110d30fcefbbd5feb1797ca35d17"
+checksum = "43864ed400b6043a4757a25c7a64a8efde741aed79a056a2fb348a406701bb35"
 dependencies = [
  "backtrace",
  "bytes",
@@ -5665,9 +5666,9 @@ dependencies = [
  "pin-project-lite",
  "signal-hook-registry",
  "slab",
- "socket2 0.5.10",
+ "socket2 0.6.0",
  "tokio-macros",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,23 +3,23 @@ members = ["crates/*"]
 resolver = "3"
 
 [workspace.package]
-version = "0.1.15"
+version = "0.1.16"
 authors = ["Brendan Graham <brendanigraham@gmail.com>"]
 edition = "2024"
 license = "AGPL-3.0-or-later"
 repository = "https://github.com/brendangraham14/steer"
 
 [workspace.dependencies]
-steer = { version = "0.1.15", path = "crates/steer" }
-steer-core = { version = "0.1.15", path = "crates/steer-core" }
-steer-grpc = { version = "0.1.15", path = "crates/steer-grpc" }
-steer-macros = { version = "0.1.15", path = "crates/steer-macros" }
-steer-proto = { version = "0.1.15", path = "crates/steer-proto" }
-steer-remote-workspace = { version = "0.1.15", path = "crates/steer-remote-workspace" }
-steer-tools = { version = "0.1.15", path = "crates/steer-tools" }
-steer-tui = { version = "0.1.15", path = "crates/steer-tui" }
-steer-workspace = { version = "0.1.15", path = "crates/steer-workspace" }
-steer-workspace-client = { version = "0.1.15", path = "crates/steer-workspace-client" }
+steer = { version = "0.1.16", path = "crates/steer" }
+steer-core = { version = "0.1.16", path = "crates/steer-core" }
+steer-grpc = { version = "0.1.16", path = "crates/steer-grpc" }
+steer-macros = { version = "0.1.16", path = "crates/steer-macros" }
+steer-proto = { version = "0.1.16", path = "crates/steer-proto" }
+steer-remote-workspace = { version = "0.1.16", path = "crates/steer-remote-workspace" }
+steer-tools = { version = "0.1.16", path = "crates/steer-tools" }
+steer-tui = { version = "0.1.16", path = "crates/steer-tui" }
+steer-workspace = { version = "0.1.16", path = "crates/steer-workspace" }
+steer-workspace-client = { version = "0.1.16", path = "crates/steer-workspace-client" }
 
 [workspace.lints.rust]
 unused_must_use = "deny"

--- a/crates/steer-core/CHANGELOG.md
+++ b/crates/steer-core/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.16](https://github.com/BrendanGraham14/steer/compare/steer-core-v0.1.15...steer-core-v0.1.16) - 2025-07-27
+
+### Fixed
+
+- don't continue the conversation after compacting
+
 ## [0.1.8](https://github.com/BrendanGraham14/steer/compare/steer-core-v0.1.7...steer-core-v0.1.8) - 2025-07-24
 
 ### Added

--- a/crates/steer-remote-workspace/CHANGELOG.md
+++ b/crates/steer-remote-workspace/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.16](https://github.com/BrendanGraham14/steer/compare/steer-remote-workspace-v0.1.15...steer-remote-workspace-v0.1.16) - 2025-07-27
+
+### Other
+
+- update Cargo.lock dependencies
+
 ## [0.1.8](https://github.com/BrendanGraham14/steer/compare/steer-remote-workspace-v0.1.7...steer-remote-workspace-v0.1.8) - 2025-07-24
 
 ### Added

--- a/crates/steer-tui/CHANGELOG.md
+++ b/crates/steer-tui/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.16](https://github.com/BrendanGraham14/steer/compare/steer-tui-v0.1.15...steer-tui-v0.1.16) - 2025-07-27
+
+### Added
+
+- *(markdown)* treat soft breaks like hard breaks
+- small cleanup for todo list formatting
+
+### Fixed
+
+- prevent integer overflow when scrolling with usize::MAX offset
+
+### Other
+
+- break input panel into separate widgets
+
 ## [0.1.15](https://github.com/BrendanGraham14/steer/compare/steer-tui-v0.1.14...steer-tui-v0.1.15) - 2025-07-25
 
 ### Other


### PR DESCRIPTION



## 🤖 New release

* `steer-macros`: 0.1.15 -> 0.1.16
* `steer-proto`: 0.1.15 -> 0.1.16
* `steer-tools`: 0.1.15 -> 0.1.16
* `steer-workspace`: 0.1.15 -> 0.1.16
* `steer-workspace-client`: 0.1.15 -> 0.1.16
* `steer-core`: 0.1.15 -> 0.1.16 (✓ API compatible changes)
* `steer-grpc`: 0.1.15 -> 0.1.16
* `steer-tui`: 0.1.15 -> 0.1.16 (✓ API compatible changes)
* `steer`: 0.1.15 -> 0.1.16
* `steer-remote-workspace`: 0.1.15 -> 0.1.16 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>


## `steer-proto`

<blockquote>

## [0.1.8](https://github.com/BrendanGraham14/steer/compare/steer-proto-v0.1.7...steer-proto-v0.1.8) - 2025-07-24

### Added

- mcp status tracking + some tool refactoring
- *(tui)* always use detailed view of todos
</blockquote>

## `steer-tools`

<blockquote>

## [0.1.8](https://github.com/BrendanGraham14/steer/compare/steer-tools-v0.1.7...steer-tools-v0.1.8) - 2025-07-24

### Added

- mcp status tracking + some tool refactoring
- *(tui)* unify/tidy todo formatting
- *(tui)* always use detailed view of todos

### Fixed

- *(bash tool)* limit {stdout|stderr} {chars|lines}

### Other

- a few more renames
</blockquote>

## `steer-workspace`

<blockquote>

## [0.1.11](https://github.com/BrendanGraham14/steer/compare/steer-workspace-v0.1.10...steer-workspace-v0.1.11) - 2025-07-25

### Added

- filter out .git from workspace file listing
</blockquote>

## `steer-workspace-client`

<blockquote>

## [0.1.8](https://github.com/BrendanGraham14/steer/compare/steer-workspace-client-v0.1.7...steer-workspace-client-v0.1.8) - 2025-07-24

### Added

- *(tui)* always use detailed view of todos
</blockquote>

## `steer-core`

<blockquote>

## [0.1.16](https://github.com/BrendanGraham14/steer/compare/steer-core-v0.1.15...steer-core-v0.1.16) - 2025-07-27

### Fixed

- don't continue the conversation after compacting
</blockquote>

## `steer-grpc`

<blockquote>

## [0.1.8](https://github.com/BrendanGraham14/steer/compare/steer-grpc-v0.1.7...steer-grpc-v0.1.8) - 2025-07-24

### Added

- mcp status tracking + some tool refactoring
- *(tui)* always use detailed view of todos

### Other

- simplify tui by passing grpc client in directly
- dead code
</blockquote>

## `steer-tui`

<blockquote>

## [0.1.16](https://github.com/BrendanGraham14/steer/compare/steer-tui-v0.1.15...steer-tui-v0.1.16) - 2025-07-27

### Added

- *(markdown)* treat soft breaks like hard breaks
- small cleanup for todo list formatting

### Fixed

- prevent integer overflow when scrolling with usize::MAX offset

### Other

- break input panel into separate widgets
</blockquote>

## `steer`

<blockquote>

## [0.1.12](https://github.com/BrendanGraham14/steer/compare/steer-v0.1.11...steer-v0.1.12) - 2025-07-25

### Other

- update Cargo.lock dependencies
</blockquote>

## `steer-remote-workspace`

<blockquote>

## [0.1.16](https://github.com/BrendanGraham14/steer/compare/steer-remote-workspace-v0.1.15...steer-remote-workspace-v0.1.16) - 2025-07-27

### Other

- update Cargo.lock dependencies
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).