### PR TITLE
chore: release v0.1.17

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3064,9 +3064,9 @@ checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "libredox"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4488594b9328dee448adb906d8b126d9b7deb7cf5c22161ee591610bb1be83c0"
+checksum = "360e552c93fa0e8152ab463bc4c4837fce76a225df11dfaeea66c313de5e61f7"
 dependencies = [
  "bitflags 2.9.1",
  "libc",
@@ -4080,9 +4080,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.16"
+version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7251471db004e509f4e75a62cca9435365b5ec7bcdff530d612ac7c87c44a792"
+checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
  "bitflags 2.9.1",
 ]
@@ -4236,9 +4236,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b008b927a85d514699ff304be84c5084598596e6cad4a6f5bc67207715fafe5f"
+checksum = "824daba0a34f8c5c5392295d381e0800f88fd986ba291699f8785f05fa344c1e"
 dependencies = [
  "axum 0.8.4",
  "base64",
@@ -4269,9 +4269,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7465280d5f73f2c5c99017a04af407b2262455a149f255ad22f2b0b29087695c"
+checksum = "ad6543c0572a4dbc125c23e6f54963ea9ba002294fd81dd4012c204219b0dcaa"
 dependencies = [
  "darling 0.21.0",
  "proc-macro2",
@@ -4430,9 +4430,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.30"
+version = "0.23.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "069a8df149a16b1a12dcc31497c3396a173844be3cac4bd40c9e7671fef96671"
+checksum = "c0ebcbd2f03de0fc1122ad9bb24b127a5a6cd51d72604a3f3c50ac459762b6cc"
 dependencies = [
  "log",
  "once_cell",
@@ -5065,7 +5065,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "steer"
-version = "0.1.16"
+version = "0.1.17"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5130,7 +5130,7 @@ dependencies = [
 
 [[package]]
 name = "steer-core"
-version = "0.1.16"
+version = "0.1.17"
 dependencies = [
  "aes-gcm",
  "async-stream",
@@ -5187,7 +5187,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util",
- "toml 0.9.2",
+ "toml 0.9.3",
  "tonic",
  "tracing",
  "tracing-appender",
@@ -5199,7 +5199,7 @@ dependencies = [
 
 [[package]]
 name = "steer-grpc"
-version = "0.1.16"
+version = "0.1.17"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5224,7 +5224,7 @@ dependencies = [
 
 [[package]]
 name = "steer-macros"
-version = "0.1.16"
+version = "0.1.17"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5234,7 +5234,7 @@ dependencies = [
 
 [[package]]
 name = "steer-proto"
-version = "0.1.16"
+version = "0.1.17"
 dependencies = [
  "prost",
  "prost-types",
@@ -5244,7 +5244,7 @@ dependencies = [
 
 [[package]]
 name = "steer-remote-workspace"
-version = "0.1.16"
+version = "0.1.17"
 dependencies = [
  "clap",
  "fuzzy-matcher",
@@ -5267,7 +5267,7 @@ dependencies = [
 
 [[package]]
 name = "steer-tools"
-version = "0.1.16"
+version = "0.1.17"
 dependencies = [
  "ast-grep-core",
  "ast-grep-language",
@@ -5299,7 +5299,7 @@ dependencies = [
 
 [[package]]
 name = "steer-tui"
-version = "0.1.16"
+version = "0.1.17"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5347,7 +5347,7 @@ dependencies = [
 
 [[package]]
 name = "steer-workspace"
-version = "0.1.16"
+version = "0.1.17"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5371,7 +5371,7 @@ dependencies = [
 
 [[package]]
 name = "steer-workspace-client"
-version = "0.1.16"
+version = "0.1.17"
 dependencies = [
  "async-trait",
  "serde",
@@ -5734,9 +5734,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed0aee96c12fa71097902e0bb061a5e1ebd766a6636bb605ba401c45c1650eac"
+checksum = "e06723639aaded957e5a80be250c1f82f274b9d23ebb4d94163668470623461c"
 dependencies = [
  "indexmap 2.10.0",
  "serde",
@@ -6865,7 +6865,7 @@ version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets 0.53.2",
+ "windows-targets 0.53.3",
 ]
 
 [[package]]
@@ -6901,10 +6901,11 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.53.2"
+version = "0.53.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c66f69fcc9ce11da9966ddb31a40968cad001c5bedeb5c2b82ede4253ab48aef"
+checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
 dependencies = [
+ "windows-link",
  "windows_aarch64_gnullvm 0.53.0",
  "windows_aarch64_msvc 0.53.0",
  "windows_i686_gnu 0.53.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,23 +3,23 @@ members = ["crates/*"]
 resolver = "3"
 
 [workspace.package]
-version = "0.1.16"
+version = "0.1.17"
 authors = ["Brendan Graham <brendanigraham@gmail.com>"]
 edition = "2024"
 license = "AGPL-3.0-or-later"
 repository = "https://github.com/brendangraham14/steer"
 
 [workspace.dependencies]
-steer = { version = "0.1.16", path = "crates/steer" }
-steer-core = { version = "0.1.16", path = "crates/steer-core" }
-steer-grpc = { version = "0.1.16", path = "crates/steer-grpc" }
-steer-macros = { version = "0.1.16", path = "crates/steer-macros" }
-steer-proto = { version = "0.1.16", path = "crates/steer-proto" }
-steer-remote-workspace = { version = "0.1.16", path = "crates/steer-remote-workspace" }
-steer-tools = { version = "0.1.16", path = "crates/steer-tools" }
-steer-tui = { version = "0.1.16", path = "crates/steer-tui" }
-steer-workspace = { version = "0.1.16", path = "crates/steer-workspace" }
-steer-workspace-client = { version = "0.1.16", path = "crates/steer-workspace-client" }
+steer = { version = "0.1.17", path = "crates/steer" }
+steer-core = { version = "0.1.17", path = "crates/steer-core" }
+steer-grpc = { version = "0.1.17", path = "crates/steer-grpc" }
+steer-macros = { version = "0.1.17", path = "crates/steer-macros" }
+steer-proto = { version = "0.1.17", path = "crates/steer-proto" }
+steer-remote-workspace = { version = "0.1.17", path = "crates/steer-remote-workspace" }
+steer-tools = { version = "0.1.17", path = "crates/steer-tools" }
+steer-tui = { version = "0.1.17", path = "crates/steer-tui" }
+steer-workspace = { version = "0.1.17", path = "crates/steer-workspace" }
+steer-workspace-client = { version = "0.1.17", path = "crates/steer-workspace-client" }
 
 [workspace.lints.rust]
 unused_must_use = "deny"

--- a/crates/steer-core/CHANGELOG.md
+++ b/crates/steer-core/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.17](https://github.com/BrendanGraham14/steer/compare/steer-core-v0.1.16...steer-core-v0.1.17) - 2025-07-29
+
+### Other
+
+- *(workspace)* delete dead container code + pass working_dir as a parm
+
 ## [0.1.16](https://github.com/BrendanGraham14/steer/compare/steer-core-v0.1.15...steer-core-v0.1.16) - 2025-07-27
 
 ### Fixed

--- a/crates/steer-grpc/CHANGELOG.md
+++ b/crates/steer-grpc/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.17](https://github.com/BrendanGraham14/steer/compare/steer-grpc-v0.1.16...steer-grpc-v0.1.17) - 2025-07-29
+
+### Other
+
+- *(workspace)* delete dead container code + pass working_dir as a parm
+
 ## [0.1.8](https://github.com/BrendanGraham14/steer/compare/steer-grpc-v0.1.7...steer-grpc-v0.1.8) - 2025-07-24
 
 ### Added

--- a/crates/steer-proto/CHANGELOG.md
+++ b/crates/steer-proto/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.17](https://github.com/BrendanGraham14/steer/compare/steer-proto-v0.1.16...steer-proto-v0.1.17) - 2025-07-29
+
+### Other
+
+- *(workspace)* delete dead container code + pass working_dir as a parm
+
 ## [0.1.8](https://github.com/BrendanGraham14/steer/compare/steer-proto-v0.1.7...steer-proto-v0.1.8) - 2025-07-24
 
 ### Added

--- a/crates/steer-workspace/CHANGELOG.md
+++ b/crates/steer-workspace/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.17](https://github.com/BrendanGraham14/steer/compare/steer-workspace-v0.1.16...steer-workspace-v0.1.17) - 2025-07-29
+
+### Other
+
+- *(workspace)* delete dead container code + pass working_dir as a parm
+
 ## [0.1.11](https://github.com/BrendanGraham14/steer/compare/steer-workspace-v0.1.10...steer-workspace-v0.1.11) - 2025-07-25
 
 ### Added

--- a/crates/steer/CHANGELOG.md
+++ b/crates/steer/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.17](https://github.com/BrendanGraham14/steer/compare/steer-v0.1.16...steer-v0.1.17) - 2025-07-29
+
+### Other
+
+- *(workspace)* delete dead container code + pass working_dir as a parm
+
 ## [0.1.12](https://github.com/BrendanGraham14/steer/compare/steer-v0.1.11...steer-v0.1.12) - 2025-07-25
 
 ### Other


### PR DESCRIPTION



## 🤖 New release

* `steer-macros`: 0.1.16 -> 0.1.17
* `steer-proto`: 0.1.16 -> 0.1.17 (✓ API compatible changes)
* `steer-tools`: 0.1.16 -> 0.1.17
* `steer-workspace`: 0.1.16 -> 0.1.17 (✓ API compatible changes)
* `steer-workspace-client`: 0.1.16 -> 0.1.17
* `steer-core`: 0.1.16 -> 0.1.17 (✓ API compatible changes)
* `steer-grpc`: 0.1.16 -> 0.1.17 (✓ API compatible changes)
* `steer-tui`: 0.1.16 -> 0.1.17
* `steer`: 0.1.16 -> 0.1.17 (✓ API compatible changes)
* `steer-remote-workspace`: 0.1.16 -> 0.1.17

<details><summary><i><b>Changelog</b></i></summary><p>


## `steer-proto`

<blockquote>

## [0.1.17](https://github.com/BrendanGraham14/steer/compare/steer-proto-v0.1.16...steer-proto-v0.1.17) - 2025-07-29

### Other

- *(workspace)* delete dead container code + pass working_dir as a parm
</blockquote>

## `steer-tools`

<blockquote>

## [0.1.8](https://github.com/BrendanGraham14/steer/compare/steer-tools-v0.1.7...steer-tools-v0.1.8) - 2025-07-24

### Added

- mcp status tracking + some tool refactoring
- *(tui)* unify/tidy todo formatting
- *(tui)* always use detailed view of todos

### Fixed

- *(bash tool)* limit {stdout|stderr} {chars|lines}

### Other

- a few more renames
</blockquote>

## `steer-workspace`

<blockquote>

## [0.1.17](https://github.com/BrendanGraham14/steer/compare/steer-workspace-v0.1.16...steer-workspace-v0.1.17) - 2025-07-29

### Other

- *(workspace)* delete dead container code + pass working_dir as a parm
</blockquote>

## `steer-workspace-client`

<blockquote>

## [0.1.8](https://github.com/BrendanGraham14/steer/compare/steer-workspace-client-v0.1.7...steer-workspace-client-v0.1.8) - 2025-07-24

### Added

- *(tui)* always use detailed view of todos
</blockquote>

## `steer-core`

<blockquote>

## [0.1.17](https://github.com/BrendanGraham14/steer/compare/steer-core-v0.1.16...steer-core-v0.1.17) - 2025-07-29

### Other

- *(workspace)* delete dead container code + pass working_dir as a parm
</blockquote>

## `steer-grpc`

<blockquote>

## [0.1.17](https://github.com/BrendanGraham14/steer/compare/steer-grpc-v0.1.16...steer-grpc-v0.1.17) - 2025-07-29

### Other

- *(workspace)* delete dead container code + pass working_dir as a parm
</blockquote>

## `steer-tui`

<blockquote>

## [0.1.16](https://github.com/BrendanGraham14/steer/compare/steer-tui-v0.1.15...steer-tui-v0.1.16) - 2025-07-27

### Added

- *(markdown)* treat soft breaks like hard breaks
- small cleanup for todo list formatting

### Fixed

- prevent integer overflow when scrolling with usize::MAX offset

### Other

- break input panel into separate widgets
</blockquote>

## `steer`

<blockquote>

## [0.1.17](https://github.com/BrendanGraham14/steer/compare/steer-v0.1.16...steer-v0.1.17) - 2025-07-29

### Other

- *(workspace)* delete dead container code + pass working_dir as a parm
</blockquote>

## `steer-remote-workspace`

<blockquote>

## [0.1.16](https://github.com/BrendanGraham14/steer/compare/steer-remote-workspace-v0.1.15...steer-remote-workspace-v0.1.16) - 2025-07-27

### Other

- update Cargo.lock dependencies
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).