### PR TITLE
chore: release v0.1.19

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -667,9 +667,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.41"
+version = "4.5.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be92d32e80243a54711e5d7ce823c35c41c9d929dc4ab58e1276f625841aadf9"
+checksum = "ed87a9d530bb41a67537289bafcac159cb3ee28460e0a4571123d2a778a6a882"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -677,9 +677,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.41"
+version = "4.5.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707eab41e9622f9139419d573eca0900137718000c517d47da73045f54331c3d"
+checksum = "64f4f3f3c77c94aff3c7e9aac9a2ca1974a5adf392a8bb751e827d6d127ab966"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1164,7 +1164,7 @@ checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users 0.5.0",
+ "redox_users 0.5.1",
  "windows-sys 0.60.2",
 ]
 
@@ -3064,9 +3064,9 @@ checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "libredox"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "360e552c93fa0e8152ab463bc4c4837fce76a225df11dfaeea66c313de5e61f7"
+checksum = "391290121bad3d37fbddad76d8f5d1c1c314cfc646d143d7e07a3086ddff0ce3"
 dependencies = [
  "bitflags 2.9.1",
  "libc",
@@ -4100,9 +4100,9 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd6f9d3d47bdd2ad6945c5015a226ec6155d0bcdfd8f7cd29f86b71f8de99d2b"
+checksum = "78eaea1f52c56d57821be178b2d47e09ff26481a6042e8e042fcb0ced068b470"
 dependencies = [
  "getrandom 0.2.16",
  "libredox",
@@ -4236,9 +4236,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824daba0a34f8c5c5392295d381e0800f88fd986ba291699f8785f05fa344c1e"
+checksum = "1f0d0d5493be0d181a62db489eab7838669b81885972ca00ceca893cf6ac2883"
 dependencies = [
  "axum 0.8.4",
  "base64",
@@ -4269,9 +4269,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad6543c0572a4dbc125c23e6f54963ea9ba002294fd81dd4012c204219b0dcaa"
+checksum = "4aebc912b8fa7d54999adc4e45601d1d95fe458f97eb0a1277eddcd6382cf4b1"
 dependencies = [
  "darling 0.21.0",
  "proc-macro2",
@@ -5065,7 +5065,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "steer"
-version = "0.1.18"
+version = "0.1.19"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5130,7 +5130,7 @@ dependencies = [
 
 [[package]]
 name = "steer-core"
-version = "0.1.18"
+version = "0.1.19"
 dependencies = [
  "aes-gcm",
  "async-stream",
@@ -5187,7 +5187,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util",
- "toml 0.9.3",
+ "toml 0.9.4",
  "tonic",
  "tracing",
  "tracing-appender",
@@ -5199,7 +5199,7 @@ dependencies = [
 
 [[package]]
 name = "steer-grpc"
-version = "0.1.18"
+version = "0.1.19"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5224,7 +5224,7 @@ dependencies = [
 
 [[package]]
 name = "steer-macros"
-version = "0.1.18"
+version = "0.1.19"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5234,7 +5234,7 @@ dependencies = [
 
 [[package]]
 name = "steer-proto"
-version = "0.1.18"
+version = "0.1.19"
 dependencies = [
  "prost",
  "prost-types",
@@ -5244,7 +5244,7 @@ dependencies = [
 
 [[package]]
 name = "steer-remote-workspace"
-version = "0.1.18"
+version = "0.1.19"
 dependencies = [
  "clap",
  "fuzzy-matcher",
@@ -5267,7 +5267,7 @@ dependencies = [
 
 [[package]]
 name = "steer-tools"
-version = "0.1.18"
+version = "0.1.19"
 dependencies = [
  "ast-grep-core",
  "ast-grep-language",
@@ -5299,7 +5299,7 @@ dependencies = [
 
 [[package]]
 name = "steer-tui"
-version = "0.1.18"
+version = "0.1.19"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5347,7 +5347,7 @@ dependencies = [
 
 [[package]]
 name = "steer-workspace"
-version = "0.1.18"
+version = "0.1.19"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5371,7 +5371,7 @@ dependencies = [
 
 [[package]]
 name = "steer-workspace-client"
-version = "0.1.18"
+version = "0.1.19"
 dependencies = [
  "async-trait",
  "serde",
@@ -5734,9 +5734,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e06723639aaded957e5a80be250c1f82f274b9d23ebb4d94163668470623461c"
+checksum = "41ae868b5a0f67631c14589f7e250c1ea2c574ee5ba21c6c8dd4b1485705a5a1"
 dependencies = [
  "indexmap 2.10.0",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "3"
 
 [workspace.package]
-version = "0.1.18"
+version = "0.1.19"
 authors = ["Brendan Graham <brendanigraham@gmail.com>"]
 edition = "2024"
 license = "AGPL-3.0-or-later"
@@ -11,16 +11,16 @@ homepage = "https://github.com/brendangraham14/steer"
 repository = "https://github.com/brendangraham14/steer"
 
 [workspace.dependencies]
-steer = { version = "0.1.18", path = "crates/steer" }
-steer-core = { version = "0.1.18", path = "crates/steer-core" }
-steer-grpc = { version = "0.1.18", path = "crates/steer-grpc" }
-steer-macros = { version = "0.1.18", path = "crates/steer-macros" }
-steer-proto = { version = "0.1.18", path = "crates/steer-proto" }
-steer-remote-workspace = { version = "0.1.18", path = "crates/steer-remote-workspace" }
-steer-tools = { version = "0.1.18", path = "crates/steer-tools" }
-steer-tui = { version = "0.1.18", path = "crates/steer-tui" }
-steer-workspace = { version = "0.1.18", path = "crates/steer-workspace" }
-steer-workspace-client = { version = "0.1.18", path = "crates/steer-workspace-client" }
+steer = { version = "0.1.19", path = "crates/steer" }
+steer-core = { version = "0.1.19", path = "crates/steer-core" }
+steer-grpc = { version = "0.1.19", path = "crates/steer-grpc" }
+steer-macros = { version = "0.1.19", path = "crates/steer-macros" }
+steer-proto = { version = "0.1.19", path = "crates/steer-proto" }
+steer-remote-workspace = { version = "0.1.19", path = "crates/steer-remote-workspace" }
+steer-tools = { version = "0.1.19", path = "crates/steer-tools" }
+steer-tui = { version = "0.1.19", path = "crates/steer-tui" }
+steer-workspace = { version = "0.1.19", path = "crates/steer-workspace" }
+steer-workspace-client = { version = "0.1.19", path = "crates/steer-workspace-client" }
 
 [workspace.lints.rust]
 unused_must_use = "deny"

--- a/crates/steer-core/CHANGELOG.md
+++ b/crates/steer-core/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.19](https://github.com/BrendanGraham14/steer/compare/steer-core-v0.1.18...steer-core-v0.1.19) - 2025-07-31
+
+### Fixed
+
+- respect the --model flag
+
 ## [0.1.17](https://github.com/BrendanGraham14/steer/compare/steer-core-v0.1.16...steer-core-v0.1.17) - 2025-07-29
 
 ### Other

--- a/crates/steer-remote-workspace/CHANGELOG.md
+++ b/crates/steer-remote-workspace/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.19](https://github.com/BrendanGraham14/steer/compare/steer-remote-workspace-v0.1.18...steer-remote-workspace-v0.1.19) - 2025-07-31
+
+### Other
+
+- support more installers
+
 ## [0.1.16](https://github.com/BrendanGraham14/steer/compare/steer-remote-workspace-v0.1.15...steer-remote-workspace-v0.1.16) - 2025-07-27
 
 ### Other

--- a/crates/steer-tui/CHANGELOG.md
+++ b/crates/steer-tui/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.19](https://github.com/BrendanGraham14/steer/compare/steer-tui-v0.1.18...steer-tui-v0.1.19) - 2025-07-31
+
+### Fixed
+
+- respect the --model flag
+
 ## [0.1.16](https://github.com/BrendanGraham14/steer/compare/steer-tui-v0.1.15...steer-tui-v0.1.16) - 2025-07-27
 
 ### Added

--- a/crates/steer/CHANGELOG.md
+++ b/crates/steer/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.19](https://github.com/BrendanGraham14/steer/compare/steer-v0.1.18...steer-v0.1.19) - 2025-07-31
+
+### Fixed
+
+- respect the --model flag
+- display session timestamps in local timezone
+
+### Other
+
+- support more installers
+
 ## [0.1.17](https://github.com/BrendanGraham14/steer/compare/steer-v0.1.16...steer-v0.1.17) - 2025-07-29
 
 ### Other


### PR DESCRIPTION



## 🤖 New release

* `steer-macros`: 0.1.18 -> 0.1.19
* `steer-proto`: 0.1.18 -> 0.1.19
* `steer-tools`: 0.1.18 -> 0.1.19
* `steer-workspace`: 0.1.18 -> 0.1.19
* `steer-workspace-client`: 0.1.18 -> 0.1.19
* `steer-core`: 0.1.18 -> 0.1.19 (✓ API compatible changes)
* `steer-grpc`: 0.1.18 -> 0.1.19
* `steer-tui`: 0.1.18 -> 0.1.19 (✓ API compatible changes)
* `steer`: 0.1.18 -> 0.1.19 (✓ API compatible changes)
* `steer-remote-workspace`: 0.1.18 -> 0.1.19 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>


## `steer-proto`

<blockquote>

## [0.1.17](https://github.com/BrendanGraham14/steer/compare/steer-proto-v0.1.16...steer-proto-v0.1.17) - 2025-07-29

### Other

- *(workspace)* delete dead container code + pass working_dir as a parm
</blockquote>

## `steer-tools`

<blockquote>

## [0.1.8](https://github.com/BrendanGraham14/steer/compare/steer-tools-v0.1.7...steer-tools-v0.1.8) - 2025-07-24

### Added

- mcp status tracking + some tool refactoring
- *(tui)* unify/tidy todo formatting
- *(tui)* always use detailed view of todos

### Fixed

- *(bash tool)* limit {stdout|stderr} {chars|lines}

### Other

- a few more renames
</blockquote>

## `steer-workspace`

<blockquote>

## [0.1.18](https://github.com/BrendanGraham14/steer/compare/steer-workspace-v0.1.17...steer-workspace-v0.1.18) - 2025-07-30

### Fixed

- *(workspace)* skip files/directories if we don't have access to them
</blockquote>

## `steer-workspace-client`

<blockquote>

## [0.1.8](https://github.com/BrendanGraham14/steer/compare/steer-workspace-client-v0.1.7...steer-workspace-client-v0.1.8) - 2025-07-24

### Added

- *(tui)* always use detailed view of todos
</blockquote>

## `steer-core`

<blockquote>

## [0.1.19](https://github.com/BrendanGraham14/steer/compare/steer-core-v0.1.18...steer-core-v0.1.19) - 2025-07-31

### Fixed

- respect the --model flag
</blockquote>

## `steer-grpc`

<blockquote>

## [0.1.17](https://github.com/BrendanGraham14/steer/compare/steer-grpc-v0.1.16...steer-grpc-v0.1.17) - 2025-07-29

### Other

- *(workspace)* delete dead container code + pass working_dir as a parm
</blockquote>

## `steer-tui`

<blockquote>

## [0.1.19](https://github.com/BrendanGraham14/steer/compare/steer-tui-v0.1.18...steer-tui-v0.1.19) - 2025-07-31

### Fixed

- respect the --model flag
</blockquote>

## `steer`

<blockquote>

## [0.1.19](https://github.com/BrendanGraham14/steer/compare/steer-v0.1.18...steer-v0.1.19) - 2025-07-31

### Fixed

- respect the --model flag
- display session timestamps in local timezone

### Other

- support more installers
</blockquote>

## `steer-remote-workspace`

<blockquote>

## [0.1.19](https://github.com/BrendanGraham14/steer/compare/steer-remote-workspace-v0.1.18...steer-remote-workspace-v0.1.19) - 2025-07-31

### Other

- support more installers
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).