### PR TITLE
fix: display session timestamps in local timezone

### DIFF
--- a/crates/steer/src/commands/session/list.rs
+++ b/crates/steer/src/commands/session/list.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use chrono::{TimeZone, Utc};
+use chrono::{Local, TimeZone, Utc};
 use eyre::{Result, eyre};
 
 use super::super::Command;
@@ -70,8 +70,14 @@ impl Command for ListSessionCommand {
             println!(
                 "{:<36} {:<20} {:<20} {:<10} {:<30}",
                 session.id,
-                session.created_at.format("%Y-%m-%d %H:%M:%S"),
-                session.updated_at.format("%Y-%m-%d %H:%M:%S"),
+                session
+                    .created_at
+                    .with_timezone(&Local)
+                    .format("%Y-%m-%d %H:%M:%S"),
+                session
+                    .updated_at
+                    .with_timezone(&Local)
+                    .format("%Y-%m-%d %H:%M:%S"),
                 session.message_count,
                 model_str,
             );
@@ -123,7 +129,10 @@ impl ListSessionCommand {
                     let nsecs = ts.nanos as u32;
                     let datetime = Utc.timestamp_opt(secs, nsecs).single();
                     match datetime {
-                        Some(dt) => dt.format("%Y-%m-%d %H:%M:%S").to_string(),
+                        Some(dt) => dt
+                            .with_timezone(&Local)
+                            .format("%Y-%m-%d %H:%M:%S")
+                            .to_string(),
                         None => "N/A".to_string(),
                     }
                 })
@@ -137,7 +146,10 @@ impl ListSessionCommand {
                     let nsecs = ts.nanos as u32;
                     let datetime = Utc.timestamp_opt(secs, nsecs).single();
                     match datetime {
-                        Some(dt) => dt.format("%Y-%m-%d %H:%M:%S").to_string(),
+                        Some(dt) => dt
+                            .with_timezone(&Local)
+                            .format("%Y-%m-%d %H:%M:%S")
+                            .to_string(),
                         None => "N/A".to_string(),
                     }
                 })

--- a/crates/steer/src/commands/session/show.rs
+++ b/crates/steer/src/commands/session/show.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use chrono::{TimeZone, Utc};
+use chrono::{Local, TimeZone, Utc};
 use eyre::{Result, eyre};
 
 use super::super::Command;
@@ -43,11 +43,15 @@ impl Command for ShowSessionCommand {
                 println!("ID: {}", info.id);
                 println!(
                     "Created: {}",
-                    info.created_at.format("%Y-%m-%d %H:%M:%S UTC")
+                    info.created_at
+                        .with_timezone(&Local)
+                        .format("%Y-%m-%d %H:%M:%S")
                 );
                 println!(
                     "Updated: {}",
-                    info.updated_at.format("%Y-%m-%d %H:%M:%S UTC")
+                    info.updated_at
+                        .with_timezone(&Local)
+                        .format("%Y-%m-%d %H:%M:%S")
                 );
                 println!("Messages: {}", info.message_count);
                 println!(
@@ -101,7 +105,10 @@ impl ShowSessionCommand {
                     let nsecs = created_at.nanos as u32;
                     let datetime = Utc.timestamp_opt(secs, nsecs).single();
                     match datetime {
-                        Some(dt) => println!("Created: {}", dt.format("%Y-%m-%d %H:%M:%S UTC")),
+                        Some(dt) => println!(
+                            "Created: {}",
+                            dt.with_timezone(&Local).format("%Y-%m-%d %H:%M:%S")
+                        ),
                         None => println!("Created: N/A"),
                     }
                 }
@@ -111,7 +118,10 @@ impl ShowSessionCommand {
                     let nsecs = updated_at.nanos as u32;
                     let datetime = Utc.timestamp_opt(secs, nsecs).single();
                     match datetime {
-                        Some(dt) => println!("Updated: {}", dt.format("%Y-%m-%d %H:%M:%S UTC")),
+                        Some(dt) => println!(
+                            "Updated: {}",
+                            dt.with_timezone(&Local).format("%Y-%m-%d %H:%M:%S")
+                        ),
                         None => println!("Updated: N/A"),
                     }
                 }


### PR DESCRIPTION
Fixes #181

## Changes
- Convert UTC timestamps to local timezone in session list command
- Convert UTC timestamps to local timezone in session show command

## Summary
The session list and show commands were displaying timestamps in UTC, which was confusing for users. This PR updates both commands to display timestamps in the
user's local timezone instead.