### PR TITLE
chore: release v0.1.20

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5129,7 +5129,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "steer"
-version = "0.1.19"
+version = "0.1.20"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5194,7 +5194,7 @@ dependencies = [
 
 [[package]]
 name = "steer-core"
-version = "0.1.19"
+version = "0.1.20"
 dependencies = [
  "aes-gcm",
  "async-stream",
@@ -5263,7 +5263,7 @@ dependencies = [
 
 [[package]]
 name = "steer-grpc"
-version = "0.1.19"
+version = "0.1.20"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5288,7 +5288,7 @@ dependencies = [
 
 [[package]]
 name = "steer-macros"
-version = "0.1.19"
+version = "0.1.20"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5298,7 +5298,7 @@ dependencies = [
 
 [[package]]
 name = "steer-proto"
-version = "0.1.19"
+version = "0.1.20"
 dependencies = [
  "prost",
  "prost-build",
@@ -5310,7 +5310,7 @@ dependencies = [
 
 [[package]]
 name = "steer-remote-workspace"
-version = "0.1.19"
+version = "0.1.20"
 dependencies = [
  "clap",
  "fuzzy-matcher",
@@ -5333,7 +5333,7 @@ dependencies = [
 
 [[package]]
 name = "steer-tools"
-version = "0.1.19"
+version = "0.1.20"
 dependencies = [
  "ast-grep-core",
  "ast-grep-language",
@@ -5365,7 +5365,7 @@ dependencies = [
 
 [[package]]
 name = "steer-tui"
-version = "0.1.19"
+version = "0.1.20"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5413,7 +5413,7 @@ dependencies = [
 
 [[package]]
 name = "steer-workspace"
-version = "0.1.19"
+version = "0.1.20"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5437,7 +5437,7 @@ dependencies = [
 
 [[package]]
 name = "steer-workspace-client"
-version = "0.1.19"
+version = "0.1.20"
 dependencies = [
  "async-trait",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "3"
 
 [workspace.package]
-version = "0.1.19"
+version = "0.1.20"
 authors = ["Brendan Graham <brendanigraham@gmail.com>"]
 edition = "2024"
 license = "AGPL-3.0-or-later"
@@ -11,16 +11,16 @@ homepage = "https://github.com/brendangraham14/steer"
 repository = "https://github.com/brendangraham14/steer"
 
 [workspace.dependencies]
-steer = { version = "0.1.19", path = "crates/steer" }
-steer-core = { version = "0.1.19", path = "crates/steer-core" }
-steer-grpc = { version = "0.1.19", path = "crates/steer-grpc" }
-steer-macros = { version = "0.1.19", path = "crates/steer-macros" }
-steer-proto = { version = "0.1.19", path = "crates/steer-proto" }
-steer-remote-workspace = { version = "0.1.19", path = "crates/steer-remote-workspace" }
-steer-tools = { version = "0.1.19", path = "crates/steer-tools" }
-steer-tui = { version = "0.1.19", path = "crates/steer-tui" }
-steer-workspace = { version = "0.1.19", path = "crates/steer-workspace" }
-steer-workspace-client = { version = "0.1.19", path = "crates/steer-workspace-client" }
+steer = { version = "0.1.20", path = "crates/steer" }
+steer-core = { version = "0.1.20", path = "crates/steer-core" }
+steer-grpc = { version = "0.1.20", path = "crates/steer-grpc" }
+steer-macros = { version = "0.1.20", path = "crates/steer-macros" }
+steer-proto = { version = "0.1.20", path = "crates/steer-proto" }
+steer-remote-workspace = { version = "0.1.20", path = "crates/steer-remote-workspace" }
+steer-tools = { version = "0.1.20", path = "crates/steer-tools" }
+steer-tui = { version = "0.1.20", path = "crates/steer-tui" }
+steer-workspace = { version = "0.1.20", path = "crates/steer-workspace" }
+steer-workspace-client = { version = "0.1.20", path = "crates/steer-workspace-client" }
 
 [workspace.lints.rust]
 unused_must_use = "deny"

--- a/crates/steer-proto/CHANGELOG.md
+++ b/crates/steer-proto/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.20](https://github.com/BrendanGraham14/steer/compare/steer-proto-v0.1.19...steer-proto-v0.1.20) - 2025-07-31
+
+### Other
+
+- vendored protoc
+
 ## [0.1.17](https://github.com/BrendanGraham14/steer/compare/steer-proto-v0.1.16...steer-proto-v0.1.17) - 2025-07-29
 
 ### Other


### PR DESCRIPTION



## 🤖 New release

* `steer-macros`: 0.1.19 -> 0.1.20
* `steer-proto`: 0.1.19 -> 0.1.20 (✓ API compatible changes)
* `steer-tools`: 0.1.19 -> 0.1.20
* `steer-workspace`: 0.1.19 -> 0.1.20
* `steer-workspace-client`: 0.1.19 -> 0.1.20
* `steer-core`: 0.1.19 -> 0.1.20
* `steer-grpc`: 0.1.19 -> 0.1.20
* `steer-tui`: 0.1.19 -> 0.1.20
* `steer`: 0.1.19 -> 0.1.20
* `steer-remote-workspace`: 0.1.19 -> 0.1.20

<details><summary><i><b>Changelog</b></i></summary><p>


## `steer-proto`

<blockquote>

## [0.1.20](https://github.com/BrendanGraham14/steer/compare/steer-proto-v0.1.19...steer-proto-v0.1.20) - 2025-07-31

### Other

- vendored protoc
</blockquote>

## `steer-tools`

<blockquote>

## [0.1.8](https://github.com/BrendanGraham14/steer/compare/steer-tools-v0.1.7...steer-tools-v0.1.8) - 2025-07-24

### Added

- mcp status tracking + some tool refactoring
- *(tui)* unify/tidy todo formatting
- *(tui)* always use detailed view of todos

### Fixed

- *(bash tool)* limit {stdout|stderr} {chars|lines}

### Other

- a few more renames
</blockquote>

## `steer-workspace`

<blockquote>

## [0.1.18](https://github.com/BrendanGraham14/steer/compare/steer-workspace-v0.1.17...steer-workspace-v0.1.18) - 2025-07-30

### Fixed

- *(workspace)* skip files/directories if we don't have access to them
</blockquote>

## `steer-workspace-client`

<blockquote>

## [0.1.8](https://github.com/BrendanGraham14/steer/compare/steer-workspace-client-v0.1.7...steer-workspace-client-v0.1.8) - 2025-07-24

### Added

- *(tui)* always use detailed view of todos
</blockquote>

## `steer-core`

<blockquote>

## [0.1.19](https://github.com/BrendanGraham14/steer/compare/steer-core-v0.1.18...steer-core-v0.1.19) - 2025-07-31

### Fixed

- respect the --model flag
</blockquote>

## `steer-grpc`

<blockquote>

## [0.1.17](https://github.com/BrendanGraham14/steer/compare/steer-grpc-v0.1.16...steer-grpc-v0.1.17) - 2025-07-29

### Other

- *(workspace)* delete dead container code + pass working_dir as a parm
</blockquote>

## `steer-tui`

<blockquote>

## [0.1.19](https://github.com/BrendanGraham14/steer/compare/steer-tui-v0.1.18...steer-tui-v0.1.19) - 2025-07-31

### Fixed

- respect the --model flag
</blockquote>

## `steer`

<blockquote>

## [0.1.19](https://github.com/BrendanGraham14/steer/compare/steer-v0.1.18...steer-v0.1.19) - 2025-07-31

### Fixed

- respect the --model flag
- display session timestamps in local timezone

### Other

- support more installers
</blockquote>

## `steer-remote-workspace`

<blockquote>

## [0.1.19](https://github.com/BrendanGraham14/steer/compare/steer-remote-workspace-v0.1.18...steer-remote-workspace-v0.1.19) - 2025-07-31

### Other

- support more installers
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).