### PR TITLE
chore: release v0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5129,7 +5129,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "steer"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5194,7 +5194,7 @@ dependencies = [
 
 [[package]]
 name = "steer-core"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "aes-gcm",
  "async-stream",
@@ -5263,7 +5263,7 @@ dependencies = [
 
 [[package]]
 name = "steer-grpc"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5288,7 +5288,7 @@ dependencies = [
 
 [[package]]
 name = "steer-macros"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5298,7 +5298,7 @@ dependencies = [
 
 [[package]]
 name = "steer-proto"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "prost",
  "prost-build",
@@ -5310,7 +5310,7 @@ dependencies = [
 
 [[package]]
 name = "steer-remote-workspace"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "clap",
  "fuzzy-matcher",
@@ -5333,7 +5333,7 @@ dependencies = [
 
 [[package]]
 name = "steer-tools"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "ast-grep-core",
  "ast-grep-language",
@@ -5365,7 +5365,7 @@ dependencies = [
 
 [[package]]
 name = "steer-tui"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5413,7 +5413,7 @@ dependencies = [
 
 [[package]]
 name = "steer-workspace"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5437,7 +5437,7 @@ dependencies = [
 
 [[package]]
 name = "steer-workspace-client"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "3"
 
 [workspace.package]
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Brendan Graham <brendanigraham@gmail.com>"]
 edition = "2024"
 license = "AGPL-3.0-or-later"
@@ -11,16 +11,16 @@ homepage = "https://github.com/brendangraham14/steer"
 repository = "https://github.com/brendangraham14/steer"
 
 [workspace.dependencies]
-steer = { version = "0.3.0", path = "crates/steer" }
-steer-core = { version = "0.3.0", path = "crates/steer-core" }
-steer-grpc = { version = "0.3.0", path = "crates/steer-grpc" }
-steer-macros = { version = "0.3.0", path = "crates/steer-macros" }
-steer-proto = { version = "0.3.0", path = "crates/steer-proto" }
-steer-remote-workspace = { version = "0.3.0", path = "crates/steer-remote-workspace" }
-steer-tools = { version = "0.3.0", path = "crates/steer-tools" }
-steer-tui = { version = "0.3.0", path = "crates/steer-tui" }
-steer-workspace = { version = "0.3.0", path = "crates/steer-workspace" }
-steer-workspace-client = { version = "0.3.0", path = "crates/steer-workspace-client" }
+steer = { version = "0.4.0", path = "crates/steer" }
+steer-core = { version = "0.4.0", path = "crates/steer-core" }
+steer-grpc = { version = "0.4.0", path = "crates/steer-grpc" }
+steer-macros = { version = "0.4.0", path = "crates/steer-macros" }
+steer-proto = { version = "0.4.0", path = "crates/steer-proto" }
+steer-remote-workspace = { version = "0.4.0", path = "crates/steer-remote-workspace" }
+steer-tools = { version = "0.4.0", path = "crates/steer-tools" }
+steer-tui = { version = "0.4.0", path = "crates/steer-tui" }
+steer-workspace = { version = "0.4.0", path = "crates/steer-workspace" }
+steer-workspace-client = { version = "0.4.0", path = "crates/steer-workspace-client" }
 
 [workspace.lints.rust]
 unused_must_use = "deny"

--- a/crates/steer-core/CHANGELOG.md
+++ b/crates/steer-core/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/BrendanGraham14/steer/compare/steer-core-v0.3.0...steer-core-v0.4.0) - 2025-08-07
+
+### Added
+
+- gpt-5
+
 ## [0.3.0](https://github.com/BrendanGraham14/steer/compare/steer-core-v0.2.0...steer-core-v0.3.0) - 2025-08-07
 
 ### Added

--- a/crates/steer-core/src/api/mod.rs
+++ b/crates/steer-core/src/api/mod.rs
@@ -90,6 +90,8 @@ pub enum Model {
     Gpt4_1Mini20250414,
     #[strum(serialize = "gpt-4.1-nano-2025-04-14")]
     Gpt4_1Nano20250414,
+    #[strum(serialize = "gpt-5-2025-08-07", serialize = "gpt-5")]
+    Gpt5_20250807,
     #[strum(serialize = "o3-2025-04-16", serialize = "o3")]
     O3_20250416,
     #[strum(serialize = "o3-pro-2025-06-10", serialize = "o3-pro")]
@@ -124,6 +126,7 @@ impl Model {
                 | Model::Grok4_0709
                 | Model::Grok3
                 | Model::Gpt4_1_20250414
+                | Model::Gpt5_20250807
                 | Model::O4Mini20250416
         )
     }
@@ -146,6 +149,7 @@ impl Model {
             Model::Gpt4_1_20250414
             | Model::Gpt4_1Mini20250414
             | Model::Gpt4_1Nano20250414
+            | Model::Gpt5_20250807
             | Model::O3_20250416
             | Model::O3Pro20250610
             | Model::O4Mini20250416 => ProviderKind::OpenAI,
@@ -170,6 +174,7 @@ impl Model {
             Model::Grok3 => vec![],
             Model::Grok3Mini => vec!["grok-mini"],
             Model::Grok4_0709 => vec!["grok"],
+            Model::Gpt5_20250807 => vec!["gpt-5"],
             _ => vec![],
         }
     }
@@ -181,6 +186,7 @@ impl Model {
                 | Model::ClaudeSonnet4_20250514
                 | Model::ClaudeOpus4_20250514
                 | Model::ClaudeOpus4_1_20250805
+                | Model::Gpt5_20250807
                 | Model::O3_20250416
                 | Model::O3Pro20250610
                 | Model::O4Mini20250416
@@ -435,5 +441,10 @@ mod tests {
         assert_eq!(Model::from_str("grok-4-0709").unwrap(), Model::Grok4_0709);
         assert_eq!(Model::from_str("grok-3-mini").unwrap(), Model::Grok3Mini);
         assert_eq!(Model::from_str("grok-mini").unwrap(), Model::Grok3Mini);
+        assert_eq!(
+            Model::from_str("gpt-5-2025-08-07").unwrap(),
+            Model::Gpt5_20250807
+        );
+        assert_eq!(Model::from_str("gpt-5").unwrap(), Model::Gpt5_20250807);
     }
 }


### PR DESCRIPTION



## 🤖 New release

* `steer-macros`: 0.3.0 -> 0.4.0
* `steer-proto`: 0.3.0 -> 0.4.0
* `steer-tools`: 0.3.0 -> 0.4.0
* `steer-workspace`: 0.3.0 -> 0.4.0
* `steer-workspace-client`: 0.3.0 -> 0.4.0
* `steer-core`: 0.3.0 -> 0.4.0 (⚠ API breaking changes)
* `steer-grpc`: 0.3.0 -> 0.4.0
* `steer-tui`: 0.3.0 -> 0.4.0
* `steer`: 0.3.0 -> 0.4.0
* `steer-remote-workspace`: 0.3.0 -> 0.4.0

### ⚠ `steer-core` breaking changes

```text
--- failure enum_no_repr_variant_discriminant_changed: enum variant had its discriminant change value ---

Description:
The enum's variant had its discriminant value change. This breaks downstream code that used its value via a numeric cast like `as isize`.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html#assigning-discriminant-values
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/enum_no_repr_variant_discriminant_changed.ron

Failed in:
  variant Model::O3_20250416 10 -> 11 in /tmp/.tmp9UweSa/steer/crates/steer-core/src/api/mod.rs:96
  variant Model::O3Pro20250610 11 -> 12 in /tmp/.tmp9UweSa/steer/crates/steer-core/src/api/mod.rs:98
  variant Model::O4Mini20250416 12 -> 13 in /tmp/.tmp9UweSa/steer/crates/steer-core/src/api/mod.rs:100
  variant Model::Gemini2_5FlashPreview0417 13 -> 14 in /tmp/.tmp9UweSa/steer/crates/steer-core/src/api/mod.rs:102
  variant Model::Gemini2_5ProPreview0506 14 -> 15 in /tmp/.tmp9UweSa/steer/crates/steer-core/src/api/mod.rs:104
  variant Model::Gemini2_5ProPreview0605 15 -> 16 in /tmp/.tmp9UweSa/steer/crates/steer-core/src/api/mod.rs:106
  variant Model::Grok3 16 -> 17 in /tmp/.tmp9UweSa/steer/crates/steer-core/src/api/mod.rs:108
  variant Model::Grok3Mini 17 -> 18 in /tmp/.tmp9UweSa/steer/crates/steer-core/src/api/mod.rs:110
  variant Model::Grok4_0709 18 -> 19 in /tmp/.tmp9UweSa/steer/crates/steer-core/src/api/mod.rs:112

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/enum_variant_added.ron

Failed in:
  variant Model:Gpt5_20250807 in /tmp/.tmp9UweSa/steer/crates/steer-core/src/api/mod.rs:94
```

<details><summary><i><b>Changelog</b></i></summary><p>


## `steer-proto`

<blockquote>

## [0.1.20](https://github.com/BrendanGraham14/steer/compare/steer-proto-v0.1.19...steer-proto-v0.1.20) - 2025-07-31

### Other

- vendored protoc
</blockquote>

## `steer-tools`

<blockquote>

## [0.1.8](https://github.com/BrendanGraham14/steer/compare/steer-tools-v0.1.7...steer-tools-v0.1.8) - 2025-07-24

### Added

- mcp status tracking + some tool refactoring
- *(tui)* unify/tidy todo formatting
- *(tui)* always use detailed view of todos

### Fixed

- *(bash tool)* limit {stdout|stderr} {chars|lines}

### Other

- a few more renames
</blockquote>

## `steer-workspace`

<blockquote>

## [0.1.18](https://github.com/BrendanGraham14/steer/compare/steer-workspace-v0.1.17...steer-workspace-v0.1.18) - 2025-07-30

### Fixed

- *(workspace)* skip files/directories if we don't have access to them
</blockquote>

## `steer-workspace-client`

<blockquote>

## [0.1.8](https://github.com/BrendanGraham14/steer/compare/steer-workspace-client-v0.1.7...steer-workspace-client-v0.1.8) - 2025-07-24

### Added

- *(tui)* always use detailed view of todos
</blockquote>

## `steer-core`

<blockquote>

## [0.4.0](https://github.com/BrendanGraham14/steer/compare/steer-core-v0.3.0...steer-core-v0.4.0) - 2025-08-07

### Added

- gpt-5
</blockquote>

## `steer-grpc`

<blockquote>

## [0.1.17](https://github.com/BrendanGraham14/steer/compare/steer-grpc-v0.1.16...steer-grpc-v0.1.17) - 2025-07-29

### Other

- *(workspace)* delete dead container code + pass working_dir as a parm
</blockquote>

## `steer-tui`

<blockquote>

## [0.3.0](https://github.com/BrendanGraham14/steer/compare/steer-tui-v0.2.0...steer-tui-v0.3.0) - 2025-08-07

### Fixed

- *(tui)* move pending tool call to active
</blockquote>

## `steer`

<blockquote>

## [0.2.0](https://github.com/BrendanGraham14/steer/compare/steer-v0.1.21...steer-v0.2.0) - 2025-08-01

### Fixed

- respect default_model preference

### Other

- support cargo binstall
</blockquote>

## `steer-remote-workspace`

<blockquote>

## [0.1.21](https://github.com/BrendanGraham14/steer/compare/steer-remote-workspace-v0.1.20...steer-remote-workspace-v0.1.21) - 2025-07-31

### Other

- update Cargo.lock dependencies
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).