### PR TITLE
chore: release v0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,9 +147,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.98"
+version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
+checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
 
 [[package]]
 name = "arc-swap"
@@ -165,7 +165,7 @@ checksum = "a807991d95797b16ed5bf7431be8d1890dccb8c1b2e560c1f0d983a4f125405d"
 dependencies = [
  "bit-set",
  "regex",
- "thiserror 2.0.12",
+ "thiserror 2.0.15",
  "tree-sitter",
 ]
 
@@ -347,9 +347,9 @@ checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
-version = "0.1.88"
+version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -537,9 +537,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.9.1"
+version = "2.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+checksum = "6a65b545ab31d687cff52899d4890855fec459eb6afe0da6417b8a18da87aa29"
 dependencies = [
  "serde",
 ]
@@ -621,9 +621,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.32"
+version = "1.2.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2352e5597e9c544d5e6d9c95190d5d27738ade584fa8db0a16e130e5c2b5296e"
+checksum = "3ee0f8803222ba5a7e2777dd72ca451868909b1ac410621b676adf07280e9b5f"
 dependencies = [
  "shlex",
 ]
@@ -667,9 +667,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.43"
+version = "4.5.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50fd97c9dc2399518aa331917ac6f274280ec5eb34e555dd291899745c48ec6f"
+checksum = "1fc0e74a703892159f5ae7d3aac52c8e6c392f5ae5f359c70b5881d60aaac318"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -677,9 +677,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.43"
+version = "4.5.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c35b5830294e1fa0462034af85cc95225a4cb07092c088c55bda3147cfcd8f65"
+checksum = "b3e7f4214277f3c7aa526a59dd3fbe306a370daee1f8b7b8c987069cd8e888a8"
 dependencies = [
  "anstream",
  "anstyle",
@@ -689,9 +689,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.41"
+version = "4.5.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef4f52386a59ca4c860f7393bcf8abd8dfd91ecccc0f774635ff68e92eeef491"
+checksum = "14cb31bb0a7d536caef2639baa7fad459e15c3144efefa6dbd1c84562c4739f6"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -902,7 +902,7 @@ version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.9.2",
  "crossterm_winapi",
  "mio",
  "parking_lot",
@@ -953,12 +953,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.21.1"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6b136475da5ef7b6ac596c0e956e37bad51b85b987ff3d5e230e964936736b2"
+checksum = "08440b3dd222c3d0433e63e097463969485f112baff337dfdaca043a0d760570"
 dependencies = [
- "darling_core 0.21.1",
- "darling_macro 0.21.1",
+ "darling_core 0.21.2",
+ "darling_macro 0.21.2",
 ]
 
 [[package]]
@@ -977,9 +977,9 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.21.1"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b44ad32f92b75fb438b04b68547e521a548be8acc339a6dacc4a7121488f53e6"
+checksum = "d25b7912bc28a04ab1b7715a68ea03aaa15662b43a1a4b2c480531fd19f8bf7e"
 dependencies = [
  "fnv",
  "ident_case",
@@ -1002,11 +1002,11 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.21.1"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b5be8a7a562d315a5b92a630c30cec6bcf663e6673f00fbb69cca66a6f521b9"
+checksum = "ce154b9bea7fb0c8e8326e62d00354000c36e79770ff21b8c84e3aa267d9d531"
 dependencies = [
- "darling_core 0.21.1",
+ "darling_core 0.21.2",
  "quote",
  "syn",
 ]
@@ -1174,7 +1174,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.9.2",
  "objc2",
 ]
 
@@ -1666,20 +1666,20 @@ dependencies = [
  "parking_lot",
  "signal-hook",
  "smallvec",
- "thiserror 2.0.12",
+ "thiserror 2.0.15",
 ]
 
 [[package]]
 name = "gix-actor"
-version = "0.35.3"
+version = "0.35.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1b1ec302f8dc059df125ed46dfdc7e9d33fe7724df19843aea53b5ffd32d5bb"
+checksum = "2d36dcf9efe32b51b12dfa33cedff8414926124e760a32f9e7a6b5580d280967"
 dependencies = [
  "bstr",
  "gix-date",
  "gix-utils",
  "itoa",
- "thiserror 2.0.12",
+ "thiserror 2.0.15",
  "winnow",
 ]
 
@@ -1696,7 +1696,7 @@ dependencies = [
  "gix-trace",
  "kstring",
  "smallvec",
- "thiserror 2.0.12",
+ "thiserror 2.0.15",
  "unicode-bom",
 ]
 
@@ -1706,7 +1706,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1db9765c69502650da68f0804e3dc2b5f8ccc6a2d104ca6c85bc40700d37540"
 dependencies = [
- "thiserror 2.0.12",
+ "thiserror 2.0.15",
 ]
 
 [[package]]
@@ -1715,7 +1715,7 @@ version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b1f1d8764958699dc764e3f727cef280ff4d1bd92c107bbf8acd85b30c1bd6f"
 dependencies = [
- "thiserror 2.0.12",
+ "thiserror 2.0.15",
 ]
 
 [[package]]
@@ -1741,7 +1741,7 @@ dependencies = [
  "gix-chunk",
  "gix-hash",
  "memmap2",
- "thiserror 2.0.12",
+ "thiserror 2.0.15",
 ]
 
 [[package]]
@@ -1760,7 +1760,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "smallvec",
- "thiserror 2.0.12",
+ "thiserror 2.0.15",
  "unicode-bom",
  "winnow",
 ]
@@ -1771,11 +1771,11 @@ version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f012703eb67e263c6c1fc96649fec47694dd3e5d2a91abfc65e4a6a6dc85309"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.9.2",
  "bstr",
  "gix-path",
  "libc",
- "thiserror 2.0.12",
+ "thiserror 2.0.15",
 ]
 
 [[package]]
@@ -1788,7 +1788,7 @@ dependencies = [
  "itoa",
  "jiff",
  "smallvec",
- "thiserror 2.0.12",
+ "thiserror 2.0.15",
 ]
 
 [[package]]
@@ -1812,7 +1812,7 @@ dependencies = [
  "gix-traverse",
  "gix-worktree",
  "imara-diff",
- "thiserror 2.0.12",
+ "thiserror 2.0.15",
 ]
 
 [[package]]
@@ -1832,7 +1832,7 @@ dependencies = [
  "gix-trace",
  "gix-utils",
  "gix-worktree",
- "thiserror 2.0.12",
+ "thiserror 2.0.15",
 ]
 
 [[package]]
@@ -1848,7 +1848,7 @@ dependencies = [
  "gix-path",
  "gix-ref",
  "gix-sec",
- "thiserror 2.0.12",
+ "thiserror 2.0.15",
 ]
 
 [[package]]
@@ -1865,7 +1865,7 @@ dependencies = [
  "libc",
  "once_cell",
  "prodash",
- "thiserror 2.0.12",
+ "thiserror 2.0.15",
  "walkdir",
 ]
 
@@ -1887,21 +1887,21 @@ dependencies = [
  "gix-trace",
  "gix-utils",
  "smallvec",
- "thiserror 2.0.12",
+ "thiserror 2.0.15",
 ]
 
 [[package]]
 name = "gix-fs"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d793f71e955d18f228d20ec433dcce6d0e8577efcdfd11d72d09d7cc2758dfd1"
+checksum = "9a4d90307d064fa7230e0f87b03231be28f8ba63b913fc15346f489519d0c304"
 dependencies = [
  "bstr",
  "fastrand",
  "gix-features",
  "gix-path",
  "gix-utils",
- "thiserror 2.0.12",
+ "thiserror 2.0.15",
 ]
 
 [[package]]
@@ -1910,7 +1910,7 @@ version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b947db8366823e7a750c254f6bb29e27e17f27e457bf336ba79b32423db62cd5"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.9.2",
  "bstr",
  "gix-features",
  "gix-path",
@@ -1925,7 +1925,7 @@ dependencies = [
  "faster-hex",
  "gix-features",
  "sha1-checked",
- "thiserror 2.0.12",
+ "thiserror 2.0.15",
 ]
 
 [[package]]
@@ -1958,7 +1958,7 @@ version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af39fde3ce4ce11371d9ce826f2936ec347318f2d1972fe98c2e7134e267e25"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.9.2",
  "bstr",
  "filetime",
  "fnv",
@@ -1977,7 +1977,7 @@ dependencies = [
  "memmap2",
  "rustix 1.0.8",
  "smallvec",
- "thiserror 2.0.12",
+ "thiserror 2.0.15",
 ]
 
 [[package]]
@@ -1988,14 +1988,14 @@ checksum = "b9fa71da90365668a621e184eb5b979904471af1b3b09b943a84bc50e8ad42ed"
 dependencies = [
  "gix-tempfile",
  "gix-utils",
- "thiserror 2.0.12",
+ "thiserror 2.0.15",
 ]
 
 [[package]]
 name = "gix-object"
-version = "0.50.1"
+version = "0.50.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aff2047f96d57bcc721426e11ec0f9efeb432d5e6ef5f1aa84cfc55198971dca"
+checksum = "d69ce108ab67b65fbd4fb7e1331502429d78baeb2eee10008bdef55765397c07"
 dependencies = [
  "bstr",
  "gix-actor",
@@ -2008,7 +2008,7 @@ dependencies = [
  "gix-validate",
  "itoa",
  "smallvec",
- "thiserror 2.0.12",
+ "thiserror 2.0.15",
  "winnow",
 ]
 
@@ -2030,7 +2030,7 @@ dependencies = [
  "gix-quote",
  "parking_lot",
  "tempfile",
- "thiserror 2.0.12",
+ "thiserror 2.0.15",
 ]
 
 [[package]]
@@ -2048,7 +2048,7 @@ dependencies = [
  "gix-path",
  "memmap2",
  "smallvec",
- "thiserror 2.0.12",
+ "thiserror 2.0.15",
 ]
 
 [[package]]
@@ -2060,7 +2060,7 @@ dependencies = [
  "bstr",
  "faster-hex",
  "gix-trace",
- "thiserror 2.0.12",
+ "thiserror 2.0.15",
 ]
 
 [[package]]
@@ -2072,7 +2072,7 @@ dependencies = [
  "bstr",
  "faster-hex",
  "gix-trace",
- "thiserror 2.0.12",
+ "thiserror 2.0.15",
 ]
 
 [[package]]
@@ -2086,7 +2086,7 @@ dependencies = [
  "gix-validate",
  "home",
  "once_cell",
- "thiserror 2.0.12",
+ "thiserror 2.0.15",
 ]
 
 [[package]]
@@ -2095,13 +2095,13 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daedead611c9bd1f3640dc90a9012b45f790201788af4d659f28d94071da7fba"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.9.2",
  "bstr",
  "gix-attributes",
  "gix-config-value",
  "gix-glob",
  "gix-path",
- "thiserror 2.0.12",
+ "thiserror 2.0.15",
 ]
 
 [[package]]
@@ -2119,7 +2119,7 @@ dependencies = [
  "gix-transport",
  "gix-utils",
  "maybe-async",
- "thiserror 2.0.12",
+ "thiserror 2.0.15",
  "winnow",
 ]
 
@@ -2131,14 +2131,14 @@ checksum = "4a375a75b4d663e8bafe3bf4940a18a23755644c13582fa326e99f8f987d83fd"
 dependencies = [
  "bstr",
  "gix-utils",
- "thiserror 2.0.12",
+ "thiserror 2.0.15",
 ]
 
 [[package]]
 name = "gix-ref"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b7a23209d4e4cbdc2086d294f5f3f8707ac6286768847024d952d8cd3278c5b"
+checksum = "b966f578079a42f4a51413b17bce476544cca1cf605753466669082f94721758"
 dependencies = [
  "gix-actor",
  "gix-features",
@@ -2151,7 +2151,7 @@ dependencies = [
  "gix-utils",
  "gix-validate",
  "memmap2",
- "thiserror 2.0.12",
+ "thiserror 2.0.15",
  "winnow",
 ]
 
@@ -2166,7 +2166,7 @@ dependencies = [
  "gix-revision",
  "gix-validate",
  "smallvec",
- "thiserror 2.0.12",
+ "thiserror 2.0.15",
 ]
 
 [[package]]
@@ -2175,7 +2175,7 @@ version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f651f2b1742f760bb8161d6743229206e962b73d9c33c41f4e4aefa6586cbd3d"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.9.2",
  "bstr",
  "gix-commitgraph",
  "gix-date",
@@ -2184,7 +2184,7 @@ dependencies = [
  "gix-object",
  "gix-revwalk",
  "gix-trace",
- "thiserror 2.0.12",
+ "thiserror 2.0.15",
 ]
 
 [[package]]
@@ -2199,7 +2199,7 @@ dependencies = [
  "gix-hashtable",
  "gix-object",
  "smallvec",
- "thiserror 2.0.12",
+ "thiserror 2.0.15",
 ]
 
 [[package]]
@@ -2208,7 +2208,7 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09f7053ed7c66633b56c57bc6ed3377be3166eaf3dc2df9f1c5ec446df6fdf2c"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.9.2",
  "gix-path",
  "libc",
  "windows-sys 0.59.0",
@@ -2223,7 +2223,7 @@ dependencies = [
  "bstr",
  "gix-hash",
  "gix-lock",
- "thiserror 2.0.12",
+ "thiserror 2.0.15",
 ]
 
 [[package]]
@@ -2246,7 +2246,7 @@ dependencies = [
  "gix-pathspec",
  "gix-worktree",
  "portable-atomic",
- "thiserror 2.0.12",
+ "thiserror 2.0.15",
 ]
 
 [[package]]
@@ -2261,7 +2261,7 @@ dependencies = [
  "gix-pathspec",
  "gix-refspec",
  "gix-url",
- "thiserror 2.0.12",
+ "thiserror 2.0.15",
 ]
 
 [[package]]
@@ -2299,7 +2299,7 @@ dependencies = [
  "gix-quote",
  "gix-sec",
  "gix-url",
- "thiserror 2.0.12",
+ "thiserror 2.0.15",
 ]
 
 [[package]]
@@ -2308,7 +2308,7 @@ version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7cdc82509d792ba0ad815f86f6b469c7afe10f94362e96c4494525a6601bdd5"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.9.2",
  "gix-commitgraph",
  "gix-date",
  "gix-hash",
@@ -2316,7 +2316,7 @@ dependencies = [
  "gix-object",
  "gix-revwalk",
  "smallvec",
- "thiserror 2.0.12",
+ "thiserror 2.0.15",
 ]
 
 [[package]]
@@ -2329,7 +2329,7 @@ dependencies = [
  "gix-features",
  "gix-path",
  "percent-encoding",
- "thiserror 2.0.12",
+ "thiserror 2.0.15",
  "url",
 ]
 
@@ -2351,7 +2351,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77b9e00cacde5b51388d28ed746c493b18a6add1f19b5e01d686b3b9ece66d4d"
 dependencies = [
  "bstr",
- "thiserror 2.0.12",
+ "thiserror 2.0.15",
 ]
 
 [[package]]
@@ -2375,9 +2375,9 @@ dependencies = [
 
 [[package]]
 name = "glob"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "globset"
@@ -2592,13 +2592,14 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
+checksum = "eb3aa54a13a0dfe7fbe3a59e0c76093041720fdc77b110cc0fc260fafb4dc51e"
 dependencies = [
+ "atomic-waker",
  "bytes",
  "futures-channel",
- "futures-util",
+ "futures-core",
  "h2",
  "http",
  "http-body",
@@ -2606,6 +2607,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
+ "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -2887,7 +2889,7 @@ version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d93587f37623a1a17d94ef2bc9ada592f5465fe7732084ab7beefabe5c77c0c4"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.9.2",
  "cfg-if",
  "libc",
 ]
@@ -3052,9 +3054,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.174"
+version = "0.2.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
+checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
 name = "libm"
@@ -3068,7 +3070,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "391290121bad3d37fbddad76d8f5d1c1c314cfc646d143d7e07a3086ddff0ce3"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.9.2",
  "libc",
  "redox_syscall",
 ]
@@ -3105,7 +3107,7 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "761e49ec5fd8a5a463f9b84e877c373d888935b71c6be78f3767fe2ae6bed18e"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.9.2",
  "libc",
 ]
 
@@ -3287,7 +3289,7 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.9.2",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -3383,9 +3385,9 @@ dependencies = [
 
 [[package]]
 name = "objc2"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88c6597e14493ab2e44ce58f2fdecf095a51f12ca57bec060a11c57332520551"
+checksum = "561f357ba7f3a2a61563a186a163d0a3a5247e1089524a3981d49adb775078bc"
 dependencies = [
  "objc2-encode",
 ]
@@ -3396,7 +3398,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c10c2894a6fed806ade6027bcd50662746363a9589d3ec9d9bef30a4e4bc166"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.9.2",
  "dispatch2",
  "objc2",
 ]
@@ -3413,7 +3415,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "900831247d2fe1a09a683278e5384cfb8c80c79fe6b166f9d14bfdde0ea1b03c"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.9.2",
  "block2",
  "libc",
  "objc2",
@@ -3447,7 +3449,7 @@ version = "6.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "336b9c63443aceef14bea841b899035ae3abe89b7c486aaf4c5bd8aafedac3f0"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.9.2",
  "libc",
  "once_cell",
  "onig_sys",
@@ -3734,9 +3736,9 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.36"
+version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff24dfcda44452b9816fff4cd4227e1bb73ff5a2f1bc1105aa92fb8565ce44d2"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn",
@@ -3753,9 +3755,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.96"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "beef09f85ae72cea1ef96ba6870c51e6382ebfa4f0e85b643459331f3daa5be0"
+checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
 dependencies = [
  "unicode-ident",
 ]
@@ -3791,7 +3793,7 @@ checksum = "6fcdab19deb5195a31cf7726a210015ff1496ba1464fd42cb4f537b8b01b471f"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.9.1",
+ "bitflags 2.9.2",
  "lazy_static",
  "num-traits",
  "rand 0.9.2",
@@ -3925,7 +3927,7 @@ version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57206b407293d2bcd3af849ce869d52068623f19e1b5ff8e8778e3309439682b"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.9.2",
  "getopts",
  "memchr",
  "unicase",
@@ -3937,7 +3939,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e8bbe1a966bd2f362681a44f6edce3c2310ac21e4d5067a6e7ec396297a6ea0"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.9.2",
  "getopts",
  "memchr",
  "pulldown-cmark-escape",
@@ -3988,7 +3990,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2 0.5.10",
- "thiserror 2.0.12",
+ "thiserror 2.0.15",
  "tokio",
  "tracing",
  "web-time",
@@ -4009,7 +4011,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.12",
+ "thiserror 2.0.15",
  "tinyvec",
  "tracing",
  "web-time",
@@ -4118,7 +4120,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.9.2",
  "cassowary",
  "compact_str",
  "crossterm",
@@ -4148,7 +4150,7 @@ version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.9.2",
 ]
 
 [[package]]
@@ -4170,7 +4172,7 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.16",
  "libredox",
- "thiserror 2.0.12",
+ "thiserror 2.0.15",
 ]
 
 [[package]]
@@ -4245,9 +4247,9 @@ checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
 name = "reqwest"
-version = "0.12.22"
+version = "0.12.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbc931937e6ca3a06e3b6c0aa7841849b160a90351d6ab467a8b9b9959767531"
+checksum = "d429f34c8092b2d42c7c93cec323bb4adeb7c67698f70839adec842ec10c7ceb"
 dependencies = [
  "base64",
  "bytes",
@@ -4322,7 +4324,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sse-stream",
- "thiserror 2.0.12",
+ "thiserror 2.0.15",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -4337,7 +4339,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad9720d9d2a943779f1dc3d47fa9072c7eeffaff4e1a82f67eb9f7ea52696091"
 dependencies = [
- "darling 0.21.1",
+ "darling 0.21.2",
  "proc-macro2",
  "quote",
  "serde_json",
@@ -4472,7 +4474,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.9.2",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -4485,7 +4487,7 @@ version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.9.2",
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
@@ -4608,7 +4610,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.9.2",
  "core-foundation 0.9.4",
  "core-foundation-sys",
  "libc",
@@ -4621,7 +4623,7 @@ version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80fb1d92c5028aa318b4b8bd7302a5bfcf48be96a37fc6fc790f806b0004ee0c"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.9.2",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -4677,9 +4679,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.142"
+version = "1.0.143"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "030fedb782600dcbd6f02d479bf0d817ac3bb40d644745b769d6a96bc3afc5a7"
+checksum = "d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a"
 dependencies = [
  "indexmap 2.10.0",
  "itoa",
@@ -4946,7 +4948,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "smallvec",
- "thiserror 2.0.12",
+ "thiserror 2.0.15",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -5001,7 +5003,7 @@ checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
 dependencies = [
  "atoi",
  "base64",
- "bitflags 2.9.1",
+ "bitflags 2.9.2",
  "byteorder",
  "bytes",
  "chrono",
@@ -5031,7 +5033,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror 2.0.12",
+ "thiserror 2.0.15",
  "tracing",
  "uuid",
  "whoami",
@@ -5045,7 +5047,7 @@ checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
 dependencies = [
  "atoi",
  "base64",
- "bitflags 2.9.1",
+ "bitflags 2.9.2",
  "byteorder",
  "chrono",
  "crc",
@@ -5070,7 +5072,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror 2.0.12",
+ "thiserror 2.0.15",
  "tracing",
  "uuid",
  "whoami",
@@ -5096,7 +5098,7 @@ dependencies = [
  "serde",
  "serde_urlencoded",
  "sqlx-core",
- "thiserror 2.0.12",
+ "thiserror 2.0.15",
  "tracing",
  "url",
  "uuid",
@@ -5129,7 +5131,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "steer"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5194,7 +5196,7 @@ dependencies = [
 
 [[package]]
 name = "steer-core"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "aes-gcm",
  "async-stream",
@@ -5265,7 +5267,7 @@ dependencies = [
 
 [[package]]
 name = "steer-grpc"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5290,7 +5292,7 @@ dependencies = [
 
 [[package]]
 name = "steer-macros"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5300,7 +5302,7 @@ dependencies = [
 
 [[package]]
 name = "steer-proto"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "prost",
  "prost-build",
@@ -5312,7 +5314,7 @@ dependencies = [
 
 [[package]]
 name = "steer-remote-workspace"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "clap",
  "fuzzy-matcher",
@@ -5335,7 +5337,7 @@ dependencies = [
 
 [[package]]
 name = "steer-tools"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "ast-grep-core",
  "ast-grep-language",
@@ -5367,7 +5369,7 @@ dependencies = [
 
 [[package]]
 name = "steer-tui"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5397,7 +5399,7 @@ dependencies = [
  "syntect",
  "tempfile",
  "textwrap",
- "thiserror 2.0.12",
+ "thiserror 2.0.15",
  "time",
  "tokio",
  "tokio-stream",
@@ -5415,7 +5417,7 @@ dependencies = [
 
 [[package]]
 name = "steer-workspace"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5430,7 +5432,7 @@ dependencies = [
  "steer-proto",
  "steer-tools",
  "tempfile",
- "thiserror 2.0.12",
+ "thiserror 2.0.15",
  "tokio",
  "tokio-util",
  "tonic",
@@ -5439,7 +5441,7 @@ dependencies = [
 
 [[package]]
 name = "steer-workspace-client"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "serde",
@@ -5447,7 +5449,7 @@ dependencies = [
  "steer-proto",
  "steer-tools",
  "steer-workspace",
- "thiserror 2.0.12",
+ "thiserror 2.0.15",
  "tokio",
  "tonic",
  "tracing",
@@ -5527,9 +5529,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.104"
+version = "2.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
+checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5585,7 +5587,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b1e66e07de489fe43a46678dd0b8df65e0c973909df1b60ba33874e297ba9b9"
 dependencies = [
  "quick-xml 0.37.5",
- "thiserror 2.0.12",
+ "thiserror 2.0.15",
  "windows",
  "windows-version",
 ]
@@ -5625,11 +5627,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.12"
+version = "2.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+checksum = "80d76d3f064b981389ecb4b6b7f45a0bf9fdac1d5b9204c7bd6714fecc302850"
 dependencies = [
- "thiserror-impl 2.0.12",
+ "thiserror-impl 2.0.15",
 ]
 
 [[package]]
@@ -5645,9 +5647,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.12"
+version = "2.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+checksum = "44d29feb33e986b6ea906bd9c3559a856983f92371b3eaa5e83782a351623de0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5706,9 +5708,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09b3661f17e86524eccd4371ab0429194e0d7c008abb45f7a7495b1719463c71"
+checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -5956,7 +5958,7 @@ version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.9.2",
  "bytes",
  "futures-util",
  "http",
@@ -6547,9 +6549,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.17.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
+checksum = "f33196643e165781c20a5ead5582283a7dacbb87855d867fbc2df3f81eddc1be"
 dependencies = [
  "getrandom 0.3.3",
  "js-sys",
@@ -7162,7 +7164,7 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.9.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "3"
 
 [workspace.package]
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Brendan Graham <brendanigraham@gmail.com>"]
 edition = "2024"
 license = "AGPL-3.0-or-later"
@@ -11,16 +11,16 @@ homepage = "https://github.com/brendangraham14/steer"
 repository = "https://github.com/brendangraham14/steer"
 
 [workspace.dependencies]
-steer = { version = "0.4.0", path = "crates/steer" }
-steer-core = { version = "0.4.0", path = "crates/steer-core" }
-steer-grpc = { version = "0.4.0", path = "crates/steer-grpc" }
-steer-macros = { version = "0.4.0", path = "crates/steer-macros" }
-steer-proto = { version = "0.4.0", path = "crates/steer-proto" }
-steer-remote-workspace = { version = "0.4.0", path = "crates/steer-remote-workspace" }
-steer-tools = { version = "0.4.0", path = "crates/steer-tools" }
-steer-tui = { version = "0.4.0", path = "crates/steer-tui" }
-steer-workspace = { version = "0.4.0", path = "crates/steer-workspace" }
-steer-workspace-client = { version = "0.4.0", path = "crates/steer-workspace-client" }
+steer = { version = "0.5.0", path = "crates/steer" }
+steer-core = { version = "0.5.0", path = "crates/steer-core" }
+steer-grpc = { version = "0.5.0", path = "crates/steer-grpc" }
+steer-macros = { version = "0.5.0", path = "crates/steer-macros" }
+steer-proto = { version = "0.5.0", path = "crates/steer-proto" }
+steer-remote-workspace = { version = "0.5.0", path = "crates/steer-remote-workspace" }
+steer-tools = { version = "0.5.0", path = "crates/steer-tools" }
+steer-tui = { version = "0.5.0", path = "crates/steer-tui" }
+steer-workspace = { version = "0.5.0", path = "crates/steer-workspace" }
+steer-workspace-client = { version = "0.5.0", path = "crates/steer-workspace-client" }
 
 [workspace.lints.rust]
 unused_must_use = "deny"

--- a/crates/steer-core/CHANGELOG.md
+++ b/crates/steer-core/CHANGELOG.md
@@ -7,6 +7,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/BrendanGraham14/steer/compare/steer-core-v0.4.0...steer-core-v0.5.0) - 2025-08-19
+
+### Added
+
+- *(core,tui)* [**breaking**] improve model UX and resolution; stricter alias/display_name validation
+- add support for a model display_name
+- expose provider auth status via gRPC and switch TUI to remote provider registry
+- catalog discovery, --catalog flag, and session config auto-
+- *(models)* Introduce data-driven model registry
+- implement ModelRegistry with config loading and merge logic
+- add modelconfig & modelparameters
+- *(core)* [**breaking**] refactor API client factory for provider-based dispatch
+- *(core)* implement ProviderRegistry for runtime provider loading
+- *(core)* introduce provider types and compile-time defaults for auth refactor
+- gpt-5 -specific prompt
+- support openai responses api + codex-mini
+
+### Fixed
+
+- *(catalog)* some configs
+- don't reference function_calls for non-claude models
+
+### Other
+
+- merge models & providers into a single catalog file
+- *(core,grpc,cli)* [**breaking**] inject ProviderRegistry and centralize AppConfig creation
+- a few more hardcoded strings
+- core app holds model registry, tui lists/resolves models via grpc
+- generate constants for builtin models
+- support bridging between legacy Model enum and new model registry
+- *(auth)* rename AuthTokens to OAuth2Token with backward compatibility
+- upgrade rmcp
+
 ## [0.4.0](https://github.com/BrendanGraham14/steer/compare/steer-core-v0.3.0...steer-core-v0.4.0) - 2025-08-07
 
 ### Added

--- a/crates/steer-grpc/CHANGELOG.md
+++ b/crates/steer-grpc/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/BrendanGraham14/steer/compare/steer-grpc-v0.4.0...steer-grpc-v0.5.0) - 2025-08-19
+
+### Added
+
+- add support for a model display_name
+- expose provider auth status via gRPC and switch TUI to remote provider registry
+- *(models)* Introduce data-driven model registry
+- expose ListModels and ListProviders endpoints
+
+### Other
+
+- merge models & providers into a single catalog file
+- *(core,grpc,cli)* [**breaking**] inject ProviderRegistry and centralize AppConfig creation
+- core app holds model registry, tui lists/resolves models via grpc
+- generate constants for builtin models
+
 ## [0.1.17](https://github.com/BrendanGraham14/steer/compare/steer-grpc-v0.1.16...steer-grpc-v0.1.17) - 2025-07-29
 
 ### Other

--- a/crates/steer-proto/CHANGELOG.md
+++ b/crates/steer-proto/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/BrendanGraham14/steer/compare/steer-proto-v0.4.0...steer-proto-v0.5.0) - 2025-08-19
+
+### Added
+
+- expose provider auth status via gRPC and switch TUI to remote provider registry
+- expose ListModels and ListProviders endpoints
+
+### Other
+
+- core app holds model registry, tui lists/resolves models via grpc
+
 ## [0.1.20](https://github.com/BrendanGraham14/steer/compare/steer-proto-v0.1.19...steer-proto-v0.1.20) - 2025-07-31
 
 ### Other

--- a/crates/steer-remote-workspace/CHANGELOG.md
+++ b/crates/steer-remote-workspace/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/BrendanGraham14/steer/compare/steer-remote-workspace-v0.4.0...steer-remote-workspace-v0.5.0) - 2025-08-19
+
+### Other
+
+- update Cargo.lock dependencies
+
 ## [0.1.21](https://github.com/BrendanGraham14/steer/compare/steer-remote-workspace-v0.1.20...steer-remote-workspace-v0.1.21) - 2025-07-31
 
 ### Other

--- a/crates/steer-tui/CHANGELOG.md
+++ b/crates/steer-tui/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/BrendanGraham14/steer/compare/steer-tui-v0.4.0...steer-tui-v0.5.0) - 2025-08-19
+
+### Added
+
+- *(core,tui)* [**breaking**] improve model UX and resolution; stricter alias/display_name validation
+- add support for a model display_name
+- expose provider auth status via gRPC and switch TUI to remote provider registry
+- *(models)* Introduce data-driven model registry
+- *(core)* [**breaking**] refactor API client factory for provider-based dispatch
+- make wrapped markdown list content start at the same place as text in initial line
+
+### Other
+
+- merge models & providers into a single catalog file
+- core app holds model registry, tui lists/resolves models via grpc
+- generate constants for builtin models
+
 ## [0.3.0](https://github.com/BrendanGraham14/steer/compare/steer-tui-v0.2.0...steer-tui-v0.3.0) - 2025-08-07
 
 ### Fixed

--- a/crates/steer/CHANGELOG.md
+++ b/crates/steer/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/BrendanGraham14/steer/compare/steer-v0.4.0...steer-v0.5.0) - 2025-08-19
+
+### Added
+
+- catalog discovery, --catalog flag, and session config auto-
+- *(models)* Introduce data-driven model registry
+- implement ModelRegistry with config loading and merge logic
+
+### Other
+
+- merge models & providers into a single catalog file
+- tweak model helptext
+- *(core,grpc,cli)* [**breaking**] inject ProviderRegistry and centralize AppConfig creation
+- a few more hardcoded strings
+- core app holds model registry, tui lists/resolves models via grpc
+- generate constants for builtin models
+- *(auth)* rename AuthTokens to OAuth2Token with backward compatibility
+
 ## [0.2.0](https://github.com/BrendanGraham14/steer/compare/steer-v0.1.21...steer-v0.2.0) - 2025-08-01
 
 ### Fixed


### PR DESCRIPTION



## 🤖 New release

* `steer-macros`: 0.4.0 -> 0.5.0
* `steer-proto`: 0.4.0 -> 0.5.0 (⚠ API breaking changes)
* `steer-tools`: 0.4.0 -> 0.5.0
* `steer-workspace`: 0.4.0 -> 0.5.0
* `steer-workspace-client`: 0.4.0 -> 0.5.0
* `steer-core`: 0.4.0 -> 0.5.0 (⚠ API breaking changes)
* `steer-grpc`: 0.4.0 -> 0.5.0 (⚠ API breaking changes)
* `steer-tui`: 0.4.0 -> 0.5.0 (⚠ API breaking changes)
* `steer`: 0.4.0 -> 0.5.0 (⚠ API breaking changes)
* `steer-remote-workspace`: 0.4.0 -> 0.5.0 (✓ API compatible changes)

### ⚠ `steer-proto` breaking changes

```text
--- failure trait_method_added: pub trait method added ---

Description:
A non-sealed public trait added a new method without a default implementation, which breaks downstream implementations of the trait
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-new-item-no-default
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/trait_method_added.ron

Failed in:
  trait method steer_proto::agent::v1::agent_service_server::AgentService::list_providers in file /tmp/.tmpHZfttO/steer/target/semver-checks/local-steer_proto-0_4_0-default-01666ec060466c14/target/debug/build/steer-proto-b258edd5be7748a1/out/steer.agent.v1.rs:2521
  trait method steer_proto::agent::v1::agent_service_server::AgentService::list_models in file /tmp/.tmpHZfttO/steer/target/semver-checks/local-steer_proto-0_4_0-default-01666ec060466c14/target/debug/build/steer-proto-b258edd5be7748a1/out/steer.agent.v1.rs:2528
  trait method steer_proto::agent::v1::agent_service_server::AgentService::resolve_model in file /tmp/.tmpHZfttO/steer/target/semver-checks/local-steer_proto-0_4_0-default-01666ec060466c14/target/debug/build/steer-proto-b258edd5be7748a1/out/steer.agent.v1.rs:2535
  trait method steer_proto::agent::v1::agent_service_server::AgentService::get_provider_auth_status in file /tmp/.tmpHZfttO/steer/target/semver-checks/local-steer_proto-0_4_0-default-01666ec060466c14/target/debug/build/steer-proto-b258edd5be7748a1/out/steer.agent.v1.rs:2543
```

### ⚠ `steer-core` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field AppConfig.model_registry in /tmp/.tmpHZfttO/steer/crates/steer-core/src/app/mod.rs:157
  field AppConfig.provider_registry in /tmp/.tmpHZfttO/steer/crates/steer-core/src/app/mod.rs:158

--- failure derive_trait_impl_removed: built-in derived trait no longer implemented ---

Description:
A public type has stopped deriving one or more traits. This can break downstream code that depends on those types implementing those traits.
        ref: https://doc.rust-lang.org/reference/attributes/derive.html#derive
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/derive_trait_impl_removed.ron

Failed in:
  type OpenAIClient no longer derives Clone, in /tmp/.tmpHZfttO/steer/crates/steer-core/src/api/openai/client.rs:16

--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/enum_missing.ron

Failed in:
  enum steer_core::api::Model, previously in file /tmp/.tmpcgSMNv/steer-core/src/api/mod.rs:67
  enum steer_core::api::ProviderKind, previously in file /tmp/.tmpcgSMNv/steer-core/src/api/mod.rs:32

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/enum_variant_added.ron

Failed in:
  variant CredentialType:OAuth2 in /tmp/.tmpHZfttO/steer/crates/steer-core/src/auth/storage.rs:40
  variant CredentialType:OAuth2 in /tmp/.tmpHZfttO/steer/crates/steer-core/src/auth/storage.rs:40
  variant Credential:OAuth2 in /tmp/.tmpHZfttO/steer/crates/steer-core/src/auth/storage.rs:22
  variant Credential:OAuth2 in /tmp/.tmpHZfttO/steer/crates/steer-core/src/auth/storage.rs:22

--- failure enum_variant_missing: pub enum variant removed or renamed ---

Description:
A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/enum_variant_missing.ron

Failed in:
  variant CredentialType::AuthTokens, previously in file /tmp/.tmpcgSMNv/steer-core/src/auth/storage.rs:34
  variant CredentialType::AuthTokens, previously in file /tmp/.tmpcgSMNv/steer-core/src/auth/storage.rs:34
  variant Credential::AuthTokens, previously in file /tmp/.tmpcgSMNv/steer-core/src/auth/storage.rs:19
  variant Credential::AuthTokens, previously in file /tmp/.tmpcgSMNv/steer-core/src/auth/storage.rs:19

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/inherent_method_missing.ron

Failed in:
  Client::new_with_provider, previously in file /tmp/.tmpcgSMNv/steer-core/src/api/mod.rs:224
  LlmConfigProvider::available_providers, previously in file /tmp/.tmpcgSMNv/steer-core/src/config/mod.rs:217
  ProviderRegistry::create_auth_flow, previously in file /tmp/.tmpcgSMNv/steer-core/src/auth/registry.rs:9
  ProviderRegistry::create_auth_flow, previously in file /tmp/.tmpcgSMNv/steer-core/src/auth/registry.rs:9
  OpenAIClient::new, previously in file /tmp/.tmpcgSMNv/steer-core/src/api/openai/client.rs:302

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/method_parameter_count_changed.ron

Failed in:
  steer_core::api::Client::complete now takes 7 parameters instead of 6, in /tmp/.tmpHZfttO/steer/crates/steer-core/src/api/mod.rs:127
  steer_core::auth::api_key::ApiKeyAuthFlow::new now takes 3 parameters instead of 2, in /tmp/.tmpHZfttO/steer/crates/steer-core/src/auth/api_key.rs:15

--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/module_missing.ron

Failed in:
  mod steer_core::api::openai::client, previously in file /tmp/.tmpcgSMNv/steer-core/src/api/openai/client.rs:1

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/struct_missing.ron

Failed in:
  struct steer_core::api::AnthropicClient, previously in file /tmp/.tmpcgSMNv/steer-core/src/api/claude/client.rs:65
  struct steer_core::api::ModelIter, previously in file /tmp/.tmpcgSMNv/steer-core/src/api/mod.rs:58
  struct steer_core::api::GeminiClient, previously in file /tmp/.tmpcgSMNv/steer-core/src/api/gemini/client.rs:39
  struct steer_core::api::XAIClient, previously in file /tmp/.tmpcgSMNv/steer-core/src/api/xai/client.rs:16
  struct steer_core::api::openai::client::OpenAIClient, previously in file /tmp/.tmpcgSMNv/steer-core/src/api/openai/client.rs:19
  struct steer_core::api::OpenAIClient, previously in file /tmp/.tmpcgSMNv/steer-core/src/api/openai/client.rs:19

--- failure trait_method_parameter_count_changed: pub trait method parameter count changed ---

Description:
A trait method now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#major-any-change-to-trait-item-signatures
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/trait_method_parameter_count_changed.ron

Failed in:
  Provider::complete now takes 7 instead of 6 parameters, in file /tmp/.tmpHZfttO/steer/crates/steer-core/src/api/provider.rs:63
  Provider::complete now takes 7 instead of 6 parameters, in file /tmp/.tmpHZfttO/steer/crates/steer-core/src/api/provider.rs:63

--- failure unit_struct_changed_kind: unit struct changed kind ---

Description:
A public unit struct has been changed to a normal (curly-braces) struct, which cannot be constructed using the same struct literal syntax.
        ref: https://github.com/rust-lang/cargo/pull/10871
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/unit_struct_changed_kind.ron

Failed in:
  struct ProviderRegistry in /tmp/.tmpHZfttO/steer/crates/steer-core/src/auth/registry.rs:10
  struct ProviderRegistry in /tmp/.tmpHZfttO/steer/crates/steer-core/src/auth/registry.rs:10
```

### ⚠ `steer-grpc` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field ServiceHostConfig.catalog_config in /tmp/.tmpHZfttO/steer/crates/steer-grpc/src/service_host.rs:28
  field ServiceHostConfig.catalog_config in /tmp/.tmpHZfttO/steer/crates/steer-grpc/src/service_host.rs:28

--- failure function_parameter_count_changed: pub fn parameter count changed ---

Description:
A publicly-visible function now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/function_parameter_count_changed.ron

Failed in:
  steer_grpc::local_server::create_local_channel now takes 3 parameters instead of 1, in /tmp/.tmpHZfttO/steer/crates/steer-grpc/src/local_server.rs:13

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/method_parameter_count_changed.ron

Failed in:
  steer_grpc::grpc::server::AgentServiceImpl::new now takes 4 parameters instead of 2, in /tmp/.tmpHZfttO/steer/crates/steer-grpc/src/grpc/server.rs:19
  steer_grpc::grpc::AgentServiceImpl::new now takes 4 parameters instead of 2, in /tmp/.tmpHZfttO/steer/crates/steer-grpc/src/grpc/server.rs:19
  steer_grpc::AgentServiceImpl::new now takes 4 parameters instead of 2, in /tmp/.tmpHZfttO/steer/crates/steer-grpc/src/grpc/server.rs:19
```

### ⚠ `steer-tui` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field SetupState.registry in /tmp/.tmpHZfttO/steer/crates/steer-tui/src/tui/state/setup.rs:16
  field SetupState.registry in /tmp/.tmpHZfttO/steer/crates/steer-tui/src/tui/state/setup.rs:16
  field MarkedLine.indent_level in /tmp/.tmpHZfttO/steer/crates/steer-tui/src/tui/widgets/markdown.rs:37

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/method_parameter_count_changed.ron

Failed in:
  steer_tui::tui::state::setup::SetupState::new now takes 2 parameters instead of 1, in /tmp/.tmpHZfttO/steer/crates/steer-tui/src/tui/state/setup.rs:82
  steer_tui::tui::state::setup::SetupState::new_for_auth_command now takes 2 parameters instead of 1, in /tmp/.tmpHZfttO/steer/crates/steer-tui/src/tui/state/setup.rs:101
  steer_tui::tui::state::SetupState::new now takes 2 parameters instead of 1, in /tmp/.tmpHZfttO/steer/crates/steer-tui/src/tui/state/setup.rs:82
  steer_tui::tui::state::SetupState::new_for_auth_command now takes 2 parameters instead of 1, in /tmp/.tmpHZfttO/steer/crates/steer-tui/src/tui/state/setup.rs:101
```

### ⚠ `steer` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field HeadlessCommand.catalogs in /tmp/.tmpHZfttO/steer/crates/steer/src/commands/headless.rs:28
  field Cli.catalogs in /tmp/.tmpHZfttO/steer/crates/steer/src/cli/args.rs:41
  field Cli.catalogs in /tmp/.tmpHZfttO/steer/crates/steer/src/cli/args.rs:41
  field ServeCommand.catalogs in /tmp/.tmpHZfttO/steer/crates/steer/src/commands/serve.rs:16

--- failure enum_struct_variant_field_added: pub enum struct variant field added ---

Description:
An enum's exhaustive struct variant has a new field, which has to be included when constructing or matching on this variant.
        ref: https://doc.rust-lang.org/reference/attributes/type_system.html#the-non_exhaustive-attribute
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/enum_struct_variant_field_added.ron

Failed in:
  field catalogs of variant Commands::Tui in /tmp/.tmpHZfttO/steer/crates/steer/src/cli/args.rs:67
  field catalogs of variant Commands::Headless in /tmp/.tmpHZfttO/steer/crates/steer/src/cli/args.rs:105
  field catalogs of variant Commands::Server in /tmp/.tmpHZfttO/steer/crates/steer/src/cli/args.rs:119
  field catalogs of variant Commands::Tui in /tmp/.tmpHZfttO/steer/crates/steer/src/cli/args.rs:67
  field catalogs of variant Commands::Headless in /tmp/.tmpHZfttO/steer/crates/steer/src/cli/args.rs:105
  field catalogs of variant Commands::Server in /tmp/.tmpHZfttO/steer/crates/steer/src/cli/args.rs:119

--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/function_missing.ron

Failed in:
  function steer::run_once, previously in file /tmp/.tmpcgSMNv/steer/src/lib.rs:64

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/struct_missing.ron

Failed in:
  struct steer::cli::args::ModelArg, previously in file /tmp/.tmpcgSMNv/steer/src/cli/args.rs:8
  struct steer::cli::ModelArg, previously in file /tmp/.tmpcgSMNv/steer/src/cli/args.rs:8
```

<details><summary><i><b>Changelog</b></i></summary><p>


## `steer-proto`

<blockquote>

## [0.5.0](https://github.com/BrendanGraham14/steer/compare/steer-proto-v0.4.0...steer-proto-v0.5.0) - 2025-08-19

### Added

- expose provider auth status via gRPC and switch TUI to remote provider registry
- expose ListModels and ListProviders endpoints

### Other

- core app holds model registry, tui lists/resolves models via grpc
</blockquote>

## `steer-tools`

<blockquote>

## [0.1.8](https://github.com/BrendanGraham14/steer/compare/steer-tools-v0.1.7...steer-tools-v0.1.8) - 2025-07-24

### Added

- mcp status tracking + some tool refactoring
- *(tui)* unify/tidy todo formatting
- *(tui)* always use detailed view of todos

### Fixed

- *(bash tool)* limit {stdout|stderr} {chars|lines}

### Other

- a few more renames
</blockquote>

## `steer-workspace`

<blockquote>

## [0.1.18](https://github.com/BrendanGraham14/steer/compare/steer-workspace-v0.1.17...steer-workspace-v0.1.18) - 2025-07-30

### Fixed

- *(workspace)* skip files/directories if we don't have access to them
</blockquote>

## `steer-workspace-client`

<blockquote>

## [0.1.8](https://github.com/BrendanGraham14/steer/compare/steer-workspace-client-v0.1.7...steer-workspace-client-v0.1.8) - 2025-07-24

### Added

- *(tui)* always use detailed view of todos
</blockquote>

## `steer-core`

<blockquote>

## [0.5.0](https://github.com/BrendanGraham14/steer/compare/steer-core-v0.4.0...steer-core-v0.5.0) - 2025-08-19

### Added

- *(core,tui)* [**breaking**] improve model UX and resolution; stricter alias/display_name validation
- add support for a model display_name
- expose provider auth status via gRPC and switch TUI to remote provider registry
- catalog discovery, --catalog flag, and session config auto-
- *(models)* Introduce data-driven model registry
- implement ModelRegistry with config loading and merge logic
- add modelconfig & modelparameters
- *(core)* [**breaking**] refactor API client factory for provider-based dispatch
- *(core)* implement ProviderRegistry for runtime provider loading
- *(core)* introduce provider types and compile-time defaults for auth refactor
- gpt-5 -specific prompt
- support openai responses api + codex-mini

### Fixed

- *(catalog)* some configs
- don't reference function_calls for non-claude models

### Other

- merge models & providers into a single catalog file
- *(core,grpc,cli)* [**breaking**] inject ProviderRegistry and centralize AppConfig creation
- a few more hardcoded strings
- core app holds model registry, tui lists/resolves models via grpc
- generate constants for builtin models
- support bridging between legacy Model enum and new model registry
- *(auth)* rename AuthTokens to OAuth2Token with backward compatibility
- upgrade rmcp
</blockquote>

## `steer-grpc`

<blockquote>

## [0.5.0](https://github.com/BrendanGraham14/steer/compare/steer-grpc-v0.4.0...steer-grpc-v0.5.0) - 2025-08-19

### Added

- add support for a model display_name
- expose provider auth status via gRPC and switch TUI to remote provider registry
- *(models)* Introduce data-driven model registry
- expose ListModels and ListProviders endpoints

### Other

- merge models & providers into a single catalog file
- *(core,grpc,cli)* [**breaking**] inject ProviderRegistry and centralize AppConfig creation
- core app holds model registry, tui lists/resolves models via grpc
- generate constants for builtin models
</blockquote>

## `steer-tui`

<blockquote>

## [0.5.0](https://github.com/BrendanGraham14/steer/compare/steer-tui-v0.4.0...steer-tui-v0.5.0) - 2025-08-19

### Added

- *(core,tui)* [**breaking**] improve model UX and resolution; stricter alias/display_name validation
- add support for a model display_name
- expose provider auth status via gRPC and switch TUI to remote provider registry
- *(models)* Introduce data-driven model registry
- *(core)* [**breaking**] refactor API client factory for provider-based dispatch
- make wrapped markdown list content start at the same place as text in initial line

### Other

- merge models & providers into a single catalog file
- core app holds model registry, tui lists/resolves models via grpc
- generate constants for builtin models
</blockquote>

## `steer`

<blockquote>

## [0.5.0](https://github.com/BrendanGraham14/steer/compare/steer-v0.4.0...steer-v0.5.0) - 2025-08-19

### Added

- catalog discovery, --catalog flag, and session config auto-
- *(models)* Introduce data-driven model registry
- implement ModelRegistry with config loading and merge logic

### Other

- merge models & providers into a single catalog file
- tweak model helptext
- *(core,grpc,cli)* [**breaking**] inject ProviderRegistry and centralize AppConfig creation
- a few more hardcoded strings
- core app holds model registry, tui lists/resolves models via grpc
- generate constants for builtin models
- *(auth)* rename AuthTokens to OAuth2Token with backward compatibility
</blockquote>

## `steer-remote-workspace`

<blockquote>

## [0.5.0](https://github.com/BrendanGraham14/steer/compare/steer-remote-workspace-v0.4.0...steer-remote-workspace-v0.5.0) - 2025-08-19

### Other

- update Cargo.lock dependencies
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).