### PR TITLE
feat(tui): add GitHub update checker and status bar badge

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5387,6 +5387,8 @@ dependencies = [
  "pulldown-cmark 0.9.6",
  "ratatui",
  "regex",
+ "reqwest",
+ "semver",
  "serde",
  "serde_json",
  "similar",

--- a/crates/steer-tui/Cargo.toml
+++ b/crates/steer-tui/Cargo.toml
@@ -62,6 +62,10 @@ strum_macros = "0.27.1"
 indexmap = { version = "2.0", features = ["std"] }
 directories = "6.0.0"
 
+# Update checker
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+semver = "1"
+
 [dev-dependencies]
 steer-proto.workspace = true
 tempfile = "3.8"

--- a/crates/steer-tui/src/tui/handlers/simple.rs
+++ b/crates/steer-tui/src/tui/handlers/simple.rs
@@ -164,6 +164,15 @@ impl Tui {
                 self.chat_viewport.state_mut().toggle_view_mode();
             }
 
+            // Open update URL with 'U' when available
+            KeyCode::Char('U') => {
+                if let crate::tui::update::UpdateStatus::Available(ref info) = self.update_status {
+                    if let Err(e) = open::that(&info.url) {
+                        tracing::warn!("Failed to open update URL: {}", e);
+                    }
+                }
+            }
+
             _ => {
                 // Try common text manipulation first
                 if self.handle_text_manipulation(key)? {

--- a/crates/steer-tui/src/tui/handlers/vim.rs
+++ b/crates/steer-tui/src/tui/handlers/vim.rs
@@ -323,6 +323,14 @@ impl Tui {
                 .move_cursor(CursorMove::Head),
             KeyCode::Char('$') => self.input_panel_state.textarea.move_cursor(CursorMove::End),
             KeyCode::Char('G') => self.chat_viewport.state_mut().scroll_to_bottom(),
+            KeyCode::Char('U') => {
+                // Open update URL when available
+                if let crate::tui::update::UpdateStatus::Available(ref info) = self.update_status {
+                    if let Err(e) = open::that(&info.url) {
+                        tracing::warn!("Failed to open update URL: {}", e);
+                    }
+                }
+            }
             KeyCode::Char('g') => {
                 if self.vim_state.pending_g {
                     self.chat_viewport.state_mut().scroll_to_top();

--- a/crates/steer-tui/src/tui/ui_layout.rs
+++ b/crates/steer-tui/src/tui/ui_layout.rs
@@ -58,8 +58,14 @@ impl UiLayout {
     }
 
     /// Render the status bar
-    pub fn render_status_bar(&self, f: &mut Frame, current_model: &ModelId, theme: &Theme) {
-        let status_bar = StatusBar::new(current_model, theme);
+    pub fn render_status_bar(
+        &self,
+        f: &mut Frame,
+        current_model: &ModelId,
+        theme: &Theme,
+        update_badge: crate::tui::widgets::status_bar::UpdateBadge,
+    ) {
+        let status_bar = StatusBar::new(current_model, theme).with_update_badge(update_badge);
         f.render_widget(status_bar, self.status_area);
     }
 }

--- a/crates/steer-tui/src/tui/update.rs
+++ b/crates/steer-tui/src/tui/update.rs
@@ -1,0 +1,127 @@
+use semver::Version;
+use serde::Deserialize;
+
+#[derive(Debug, Clone)]
+pub enum UpdateStatus {
+    Unknown,
+    Checking,
+    UpToDate,
+    Available(UpdateInfo),
+}
+
+#[derive(Debug, Clone)]
+pub struct UpdateInfo {
+    pub latest: String,
+    pub url: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct GithubRelease {
+    tag_name: String,
+    html_url: String,
+}
+
+fn normalize_tag(tag: &str) -> Option<String> {
+    let t = tag.trim();
+    if let Some(rest) = t.strip_prefix("steer-v") {
+        return Some(rest.to_string());
+    }
+    if let Some(rest) = t.strip_prefix('v') {
+        return Some(rest.to_string());
+    }
+    if Version::parse(t).is_ok() {
+        return Some(t.to_string());
+    }
+    None
+}
+
+fn parse_version(s: &str) -> Option<Version> {
+    normalize_tag(s).and_then(|n| Version::parse(&n).ok())
+}
+
+pub async fn check_latest(repo_owner: &str, repo_name: &str, current: &str) -> UpdateStatus {
+    let current_ver = match Version::parse(current) {
+        Ok(v) => v,
+        Err(_) => return UpdateStatus::Unknown,
+    };
+
+    let url = format!("https://api.github.com/repos/{repo_owner}/{repo_name}/releases/latest");
+
+    let client = reqwest::Client::builder()
+        .user_agent(format!("steer-tui/{current}"))
+        .build();
+    let client = match client {
+        Ok(c) => c,
+        Err(_) => return UpdateStatus::Unknown,
+    };
+
+    let resp = match client
+        .get(url)
+        .header("Accept", "application/vnd.github+json")
+        .send()
+        .await
+    {
+        Ok(r) => r,
+        Err(_) => return UpdateStatus::Unknown,
+    };
+
+    if !resp.status().is_success() {
+        return UpdateStatus::Unknown;
+    }
+
+    let release: GithubRelease = match resp.json().await {
+        Ok(j) => j,
+        Err(_) => return UpdateStatus::Unknown,
+    };
+
+    let latest_ver = match parse_version(&release.tag_name) {
+        Some(v) => v,
+        None => return UpdateStatus::Unknown,
+    };
+
+    if latest_ver > current_ver {
+        UpdateStatus::Available(UpdateInfo {
+            latest: latest_ver.to_string(),
+            url: release.html_url,
+        })
+    } else {
+        UpdateStatus::UpToDate
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_normalize_tag() {
+        assert_eq!(normalize_tag("steer-v1.2.3"), Some("1.2.3".to_string()));
+        assert_eq!(normalize_tag("v1.2.3"), Some("1.2.3".to_string()));
+        assert_eq!(normalize_tag("1.2.3"), Some("1.2.3".to_string()));
+        assert_eq!(normalize_tag(" v1.2.3 "), Some("1.2.3".to_string()));
+        assert_eq!(normalize_tag("weird-v1.2.3"), None);
+        assert_eq!(normalize_tag("steer-1.2.3"), None);
+        assert_eq!(normalize_tag("V1.2.3"), None);
+    }
+
+    #[test]
+    fn test_parse_version() {
+        assert!(parse_version("steer-v1.2.3").is_some());
+        assert!(parse_version("v1.2.3").is_some());
+        assert!(parse_version("1.2.3").is_some());
+        assert!(parse_version("not-a-version").is_none());
+        assert!(parse_version("").is_none());
+        assert!(parse_version("weird-v1.2.3").is_none());
+    }
+
+    #[test]
+    fn test_version_comparison() {
+        let v1 = parse_version("v0.3.0").unwrap();
+        let v2 = parse_version("v0.4.0").unwrap();
+        assert!(v2 > v1);
+
+        let v3 = parse_version("0.4.0").unwrap();
+        let v4 = parse_version("v0.4.0").unwrap();
+        assert_eq!(v3, v4);
+    }
+}

--- a/crates/steer-tui/src/tui/widgets/status_bar.rs
+++ b/crates/steer-tui/src/tui/widgets/status_bar.rs
@@ -3,16 +3,25 @@
 use ratatui::{
     buffer::Buffer,
     layout::{Alignment, Rect},
+    text::{Line, Span},
     widgets::{Paragraph, Widget},
 };
 
 use crate::tui::theme::{Component, Theme};
 use steer_core::config::model::ModelId;
 
+/// Optional update badge info
+#[derive(Clone, Debug)]
+pub enum UpdateBadge<'a> {
+    None,
+    Available { latest: &'a str },
+}
+
 /// A status bar widget that displays the current model and other status information
 pub struct StatusBar<'a> {
     current_model: &'a ModelId,
     theme: &'a Theme,
+    update: UpdateBadge<'a>,
 }
 
 impl<'a> StatusBar<'a> {
@@ -21,21 +30,43 @@ impl<'a> StatusBar<'a> {
         Self {
             current_model,
             theme,
+            update: UpdateBadge::None,
         }
+    }
+
+    pub fn with_update_badge(mut self, update: UpdateBadge<'a>) -> Self {
+        self.update = update;
+        self
     }
 }
 
 impl Widget for StatusBar<'_> {
     fn render(self, area: Rect, buf: &mut Buffer) {
-        let status_text = format!(
+        let style = self.theme.style(Component::StatusBar);
+
+        // Left: update badge (if any)
+        let left_line = match self.update {
+            UpdateBadge::Available { latest } => Line::from(vec![Span::styled(
+                format!(" v{latest} available "),
+                self.theme.style(Component::NoticeWarn),
+            )]),
+            UpdateBadge::None => Line::from(" "),
+        };
+        let left_para = Paragraph::new(left_line)
+            .style(style)
+            .alignment(Alignment::Left);
+        left_para.render(area, buf);
+
+        // Right: current model
+        let model_string = format!(
             " {}/{} ",
             self.current_model.0.storage_key(),
             self.current_model.1
         );
-        let style = self.theme.style(Component::StatusBar);
-        let paragraph = Paragraph::new(status_text)
+        let right_line = Line::from(vec![Span::raw(model_string)]);
+        let right_para = Paragraph::new(right_line)
             .style(style)
             .alignment(Alignment::Right);
-        paragraph.render(area, buf);
+        right_para.render(area, buf);
     }
 }


### PR DESCRIPTION
- Add async update checker querying releases/latest via reqwest + semver
- Show 'vX.Y.Z available' badge in status bar when newer version exists
- Open release URL with 'U' in simple and vim handlers
- Wire update status into Tui event loop and rendering
- New module: crates/steer-tui/src/tui/update.rs with tests
- Add deps: reqwest (rustls-tls, json), semver