### PR TITLE
chore: release v0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3654,7 +3654,7 @@ checksum = "3af6b589e163c5a788fab00ce0c0366f6efbb9959c2f9874b224936af7fce7e1"
 dependencies = [
  "base64",
  "indexmap 2.10.0",
- "quick-xml 0.38.1",
+ "quick-xml 0.38.2",
  "serde",
  "time",
 ]
@@ -3969,9 +3969,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.38.1"
+version = "0.38.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9845d9dccf565065824e69f9f235fafba1587031eda353c1f1561cd6a6be78f4"
+checksum = "d200a41a7797e6461bd04e4e95c3347053a731c32c87f066f2f0dda22dbdbba8"
 dependencies = [
  "memchr",
 ]
@@ -5131,7 +5131,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "steer"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5196,7 +5196,7 @@ dependencies = [
 
 [[package]]
 name = "steer-core"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "aes-gcm",
  "async-stream",
@@ -5267,7 +5267,7 @@ dependencies = [
 
 [[package]]
 name = "steer-grpc"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5292,7 +5292,7 @@ dependencies = [
 
 [[package]]
 name = "steer-macros"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5302,7 +5302,7 @@ dependencies = [
 
 [[package]]
 name = "steer-proto"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "prost",
  "prost-build",
@@ -5314,7 +5314,7 @@ dependencies = [
 
 [[package]]
 name = "steer-remote-workspace"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "clap",
  "fuzzy-matcher",
@@ -5337,7 +5337,7 @@ dependencies = [
 
 [[package]]
 name = "steer-tools"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "ast-grep-core",
  "ast-grep-language",
@@ -5369,7 +5369,7 @@ dependencies = [
 
 [[package]]
 name = "steer-tui"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5419,7 +5419,7 @@ dependencies = [
 
 [[package]]
 name = "steer-workspace"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5443,7 +5443,7 @@ dependencies = [
 
 [[package]]
 name = "steer-workspace-client"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "3"
 
 [workspace.package]
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Brendan Graham <brendanigraham@gmail.com>"]
 edition = "2024"
 license = "AGPL-3.0-or-later"
@@ -11,16 +11,16 @@ homepage = "https://github.com/brendangraham14/steer"
 repository = "https://github.com/brendangraham14/steer"
 
 [workspace.dependencies]
-steer = { version = "0.5.0", path = "crates/steer" }
-steer-core = { version = "0.5.0", path = "crates/steer-core" }
-steer-grpc = { version = "0.5.0", path = "crates/steer-grpc" }
-steer-macros = { version = "0.5.0", path = "crates/steer-macros" }
-steer-proto = { version = "0.5.0", path = "crates/steer-proto" }
-steer-remote-workspace = { version = "0.5.0", path = "crates/steer-remote-workspace" }
-steer-tools = { version = "0.5.0", path = "crates/steer-tools" }
-steer-tui = { version = "0.5.0", path = "crates/steer-tui" }
-steer-workspace = { version = "0.5.0", path = "crates/steer-workspace" }
-steer-workspace-client = { version = "0.5.0", path = "crates/steer-workspace-client" }
+steer = { version = "0.6.0", path = "crates/steer" }
+steer-core = { version = "0.6.0", path = "crates/steer-core" }
+steer-grpc = { version = "0.6.0", path = "crates/steer-grpc" }
+steer-macros = { version = "0.6.0", path = "crates/steer-macros" }
+steer-proto = { version = "0.6.0", path = "crates/steer-proto" }
+steer-remote-workspace = { version = "0.6.0", path = "crates/steer-remote-workspace" }
+steer-tools = { version = "0.6.0", path = "crates/steer-tools" }
+steer-tui = { version = "0.6.0", path = "crates/steer-tui" }
+steer-workspace = { version = "0.6.0", path = "crates/steer-workspace" }
+steer-workspace-client = { version = "0.6.0", path = "crates/steer-workspace-client" }
 
 [workspace.lints.rust]
 unused_must_use = "deny"

--- a/crates/steer-core/CHANGELOG.md
+++ b/crates/steer-core/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/BrendanGraham14/steer/compare/steer-core-v0.5.0...steer-core-v0.6.0) - 2025-08-19
+
+### Other
+
+- cleaner tool error propagation
+
 ## [0.5.0](https://github.com/BrendanGraham14/steer/compare/steer-core-v0.4.0...steer-core-v0.5.0) - 2025-08-19
 
 ### Added

--- a/crates/steer-proto/CHANGELOG.md
+++ b/crates/steer-proto/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/BrendanGraham14/steer/compare/steer-proto-v0.5.0...steer-proto-v0.6.0) - 2025-08-19
+
+### Other
+
+- cleaner tool error propagation
+
 ## [0.5.0](https://github.com/BrendanGraham14/steer/compare/steer-proto-v0.4.0...steer-proto-v0.5.0) - 2025-08-19
 
 ### Added

--- a/crates/steer-remote-workspace/CHANGELOG.md
+++ b/crates/steer-remote-workspace/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/BrendanGraham14/steer/compare/steer-remote-workspace-v0.5.0...steer-remote-workspace-v0.6.0) - 2025-08-19
+
+### Other
+
+- cleaner tool error propagation
+
 ## [0.5.0](https://github.com/BrendanGraham14/steer/compare/steer-remote-workspace-v0.4.0...steer-remote-workspace-v0.5.0) - 2025-08-19
 
 ### Other

--- a/crates/steer-tui/CHANGELOG.md
+++ b/crates/steer-tui/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/BrendanGraham14/steer/compare/steer-tui-v0.5.0...steer-tui-v0.6.0) - 2025-08-19
+
+### Added
+
+- *(tui)* add GitHub update checker and status bar badge
+
+### Other
+
+- cleaner tool error propagation
+
 ## [0.5.0](https://github.com/BrendanGraham14/steer/compare/steer-tui-v0.4.0...steer-tui-v0.5.0) - 2025-08-19
 
 ### Added

--- a/crates/steer-workspace-client/CHANGELOG.md
+++ b/crates/steer-workspace-client/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/BrendanGraham14/steer/compare/steer-workspace-client-v0.5.0...steer-workspace-client-v0.6.0) - 2025-08-19
+
+### Other
+
+- cleaner tool error propagation
+
 ## [0.1.8](https://github.com/BrendanGraham14/steer/compare/steer-workspace-client-v0.1.7...steer-workspace-client-v0.1.8) - 2025-07-24
 
 ### Added

--- a/crates/steer-workspace/CHANGELOG.md
+++ b/crates/steer-workspace/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/BrendanGraham14/steer/compare/steer-workspace-v0.5.0...steer-workspace-v0.6.0) - 2025-08-19
+
+### Other
+
+- cleaner tool error propagation
+
 ## [0.1.18](https://github.com/BrendanGraham14/steer/compare/steer-workspace-v0.1.17...steer-workspace-v0.1.18) - 2025-07-30
 
 ### Fixed


### PR DESCRIPTION



## 🤖 New release

* `steer-macros`: 0.5.0 -> 0.6.0
* `steer-proto`: 0.5.0 -> 0.6.0 (⚠ API breaking changes)
* `steer-tools`: 0.5.0 -> 0.6.0
* `steer-workspace`: 0.5.0 -> 0.6.0 (✓ API compatible changes)
* `steer-workspace-client`: 0.5.0 -> 0.6.0 (✓ API compatible changes)
* `steer-core`: 0.5.0 -> 0.6.0 (✓ API compatible changes)
* `steer-grpc`: 0.5.0 -> 0.6.0
* `steer-tui`: 0.5.0 -> 0.6.0 (✓ API compatible changes)
* `steer`: 0.5.0 -> 0.6.0
* `steer-remote-workspace`: 0.5.0 -> 0.6.0 (✓ API compatible changes)

### ⚠ `steer-proto` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field ExecuteToolResponse.error_detail in /tmp/.tmpO8KtbR/steer/target/semver-checks/local-steer_proto-0_5_0-default-01666ec060466c14/target/debug/build/steer-proto-bf5353c80ee8dda0/out/steer.remote_workspace.v1.rs:34
```

<details><summary><i><b>Changelog</b></i></summary><p>


## `steer-proto`

<blockquote>

## [0.6.0](https://github.com/BrendanGraham14/steer/compare/steer-proto-v0.5.0...steer-proto-v0.6.0) - 2025-08-19

### Other

- cleaner tool error propagation
</blockquote>

## `steer-tools`

<blockquote>

## [0.1.8](https://github.com/BrendanGraham14/steer/compare/steer-tools-v0.1.7...steer-tools-v0.1.8) - 2025-07-24

### Added

- mcp status tracking + some tool refactoring
- *(tui)* unify/tidy todo formatting
- *(tui)* always use detailed view of todos

### Fixed

- *(bash tool)* limit {stdout|stderr} {chars|lines}

### Other

- a few more renames
</blockquote>

## `steer-workspace`

<blockquote>

## [0.6.0](https://github.com/BrendanGraham14/steer/compare/steer-workspace-v0.5.0...steer-workspace-v0.6.0) - 2025-08-19

### Other

- cleaner tool error propagation
</blockquote>

## `steer-workspace-client`

<blockquote>

## [0.6.0](https://github.com/BrendanGraham14/steer/compare/steer-workspace-client-v0.5.0...steer-workspace-client-v0.6.0) - 2025-08-19

### Other

- cleaner tool error propagation
</blockquote>

## `steer-core`

<blockquote>

## [0.6.0](https://github.com/BrendanGraham14/steer/compare/steer-core-v0.5.0...steer-core-v0.6.0) - 2025-08-19

### Other

- cleaner tool error propagation
</blockquote>

## `steer-grpc`

<blockquote>

## [0.5.0](https://github.com/BrendanGraham14/steer/compare/steer-grpc-v0.4.0...steer-grpc-v0.5.0) - 2025-08-19

### Added

- add support for a model display_name
- expose provider auth status via gRPC and switch TUI to remote provider registry
- *(models)* Introduce data-driven model registry
- expose ListModels and ListProviders endpoints

### Other

- merge models & providers into a single catalog file
- *(core,grpc,cli)* [**breaking**] inject ProviderRegistry and centralize AppConfig creation
- core app holds model registry, tui lists/resolves models via grpc
- generate constants for builtin models
</blockquote>

## `steer-tui`

<blockquote>

## [0.6.0](https://github.com/BrendanGraham14/steer/compare/steer-tui-v0.5.0...steer-tui-v0.6.0) - 2025-08-19

### Added

- *(tui)* add GitHub update checker and status bar badge

### Other

- cleaner tool error propagation
</blockquote>

## `steer`

<blockquote>

## [0.5.0](https://github.com/BrendanGraham14/steer/compare/steer-v0.4.0...steer-v0.5.0) - 2025-08-19

### Added

- catalog discovery, --catalog flag, and session config auto-
- *(models)* Introduce data-driven model registry
- implement ModelRegistry with config loading and merge logic

### Other

- merge models & providers into a single catalog file
- tweak model helptext
- *(core,grpc,cli)* [**breaking**] inject ProviderRegistry and centralize AppConfig creation
- a few more hardcoded strings
- core app holds model registry, tui lists/resolves models via grpc
- generate constants for builtin models
- *(auth)* rename AuthTokens to OAuth2Token with backward compatibility
</blockquote>

## `steer-remote-workspace`

<blockquote>

## [0.6.0](https://github.com/BrendanGraham14/steer/compare/steer-remote-workspace-v0.5.0...steer-remote-workspace-v0.6.0) - 2025-08-19

### Other

- cleaner tool error propagation
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).