### PR TITLE
chore: release v0.8.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5296,7 +5296,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "steer"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5361,7 +5361,7 @@ dependencies = [
 
 [[package]]
 name = "steer-core"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "aes-gcm",
  "async-stream",
@@ -5432,7 +5432,7 @@ dependencies = [
 
 [[package]]
 name = "steer-grpc"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5457,7 +5457,7 @@ dependencies = [
 
 [[package]]
 name = "steer-macros"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5467,7 +5467,7 @@ dependencies = [
 
 [[package]]
 name = "steer-proto"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "prost",
  "prost-build",
@@ -5479,7 +5479,7 @@ dependencies = [
 
 [[package]]
 name = "steer-remote-workspace"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "clap",
  "fuzzy-matcher",
@@ -5502,7 +5502,7 @@ dependencies = [
 
 [[package]]
 name = "steer-tools"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "ast-grep-core",
  "ast-grep-language",
@@ -5534,7 +5534,7 @@ dependencies = [
 
 [[package]]
 name = "steer-tui"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5585,7 +5585,7 @@ dependencies = [
 
 [[package]]
 name = "steer-workspace"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5609,7 +5609,7 @@ dependencies = [
 
 [[package]]
 name = "steer-workspace-client"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "async-trait",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "3"
 
 [workspace.package]
-version = "0.8.0"
+version = "0.8.1"
 authors = ["Brendan Graham <brendanigraham@gmail.com>"]
 edition = "2024"
 license = "AGPL-3.0-or-later"
@@ -11,16 +11,16 @@ homepage = "https://github.com/brendangraham14/steer"
 repository = "https://github.com/brendangraham14/steer"
 
 [workspace.dependencies]
-steer = { version = "0.8.0", path = "crates/steer" }
-steer-core = { version = "0.8.0", path = "crates/steer-core" }
-steer-grpc = { version = "0.8.0", path = "crates/steer-grpc" }
-steer-macros = { version = "0.8.0", path = "crates/steer-macros" }
-steer-proto = { version = "0.8.0", path = "crates/steer-proto" }
-steer-remote-workspace = { version = "0.8.0", path = "crates/steer-remote-workspace" }
-steer-tools = { version = "0.8.0", path = "crates/steer-tools" }
-steer-tui = { version = "0.8.0", path = "crates/steer-tui" }
-steer-workspace = { version = "0.8.0", path = "crates/steer-workspace" }
-steer-workspace-client = { version = "0.8.0", path = "crates/steer-workspace-client" }
+steer = { version = "0.8.1", path = "crates/steer" }
+steer-core = { version = "0.8.1", path = "crates/steer-core" }
+steer-grpc = { version = "0.8.1", path = "crates/steer-grpc" }
+steer-macros = { version = "0.8.1", path = "crates/steer-macros" }
+steer-proto = { version = "0.8.1", path = "crates/steer-proto" }
+steer-remote-workspace = { version = "0.8.1", path = "crates/steer-remote-workspace" }
+steer-tools = { version = "0.8.1", path = "crates/steer-tools" }
+steer-tui = { version = "0.8.1", path = "crates/steer-tui" }
+steer-workspace = { version = "0.8.1", path = "crates/steer-workspace" }
+steer-workspace-client = { version = "0.8.1", path = "crates/steer-workspace-client" }
 
 [workspace.lints.rust]
 unused_must_use = "deny"

--- a/crates/steer-remote-workspace/CHANGELOG.md
+++ b/crates/steer-remote-workspace/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.1](https://github.com/BrendanGraham14/steer/compare/steer-remote-workspace-v0.8.0...steer-remote-workspace-v0.8.1) - 2025-08-28
+
+### Other
+
+- update Cargo.lock dependencies
+
 ## [0.6.0](https://github.com/BrendanGraham14/steer/compare/steer-remote-workspace-v0.5.0...steer-remote-workspace-v0.6.0) - 2025-08-19
 
 ### Other


### PR DESCRIPTION



## 🤖 New release

* `steer-macros`: 0.8.0 -> 0.8.1
* `steer-proto`: 0.8.0 -> 0.8.1
* `steer-tools`: 0.8.0 -> 0.8.1
* `steer-workspace`: 0.8.0 -> 0.8.1
* `steer-workspace-client`: 0.8.0 -> 0.8.1
* `steer-core`: 0.8.0 -> 0.8.1
* `steer-grpc`: 0.8.0 -> 0.8.1
* `steer-tui`: 0.8.0 -> 0.8.1
* `steer`: 0.8.0 -> 0.8.1
* `steer-remote-workspace`: 0.8.0 -> 0.8.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>


## `steer-proto`

<blockquote>

## [0.6.0](https://github.com/BrendanGraham14/steer/compare/steer-proto-v0.5.0...steer-proto-v0.6.0) - 2025-08-19

### Other

- cleaner tool error propagation
</blockquote>

## `steer-tools`

<blockquote>

## [0.1.8](https://github.com/BrendanGraham14/steer/compare/steer-tools-v0.1.7...steer-tools-v0.1.8) - 2025-07-24

### Added

- mcp status tracking + some tool refactoring
- *(tui)* unify/tidy todo formatting
- *(tui)* always use detailed view of todos

### Fixed

- *(bash tool)* limit {stdout|stderr} {chars|lines}

### Other

- a few more renames
</blockquote>

## `steer-workspace`

<blockquote>

## [0.6.0](https://github.com/BrendanGraham14/steer/compare/steer-workspace-v0.5.0...steer-workspace-v0.6.0) - 2025-08-19

### Other

- cleaner tool error propagation
</blockquote>

## `steer-workspace-client`

<blockquote>

## [0.6.0](https://github.com/BrendanGraham14/steer/compare/steer-workspace-client-v0.5.0...steer-workspace-client-v0.6.0) - 2025-08-19

### Other

- cleaner tool error propagation
</blockquote>

## `steer-core`

<blockquote>

## [0.7.0](https://github.com/BrendanGraham14/steer/compare/steer-core-v0.6.0...steer-core-v0.7.0) - 2025-08-21

### Fixed

- *(core)* respect thinking_config across providers
</blockquote>

## `steer-grpc`

<blockquote>

## [0.5.0](https://github.com/BrendanGraham14/steer/compare/steer-grpc-v0.4.0...steer-grpc-v0.5.0) - 2025-08-19

### Added

- add support for a model display_name
- expose provider auth status via gRPC and switch TUI to remote provider registry
- *(models)* Introduce data-driven model registry
- expose ListModels and ListProviders endpoints

### Other

- merge models & providers into a single catalog file
- *(core,grpc,cli)* [**breaking**] inject ProviderRegistry and centralize AppConfig creation
- core app holds model registry, tui lists/resolves models via grpc
- generate constants for builtin models
</blockquote>

## `steer-tui`

<blockquote>

## [0.8.0](https://github.com/BrendanGraham14/steer/compare/steer-tui-v0.7.0...steer-tui-v0.8.0) - 2025-08-28

### Fixed

- clean up terminal properly in error states

### Other

- *(tui)* stabilize cache keys and reduce re-rendering in chat widgets
- message rendering benches
</blockquote>

## `steer`

<blockquote>

## [0.8.0](https://github.com/BrendanGraham14/steer/compare/steer-v0.7.0...steer-v0.8.0) - 2025-08-28

### Fixed

- clean up terminal properly in error states
</blockquote>

## `steer-remote-workspace`

<blockquote>

## [0.8.1](https://github.com/BrendanGraham14/steer/compare/steer-remote-workspace-v0.8.0...steer-remote-workspace-v0.8.1) - 2025-08-28

### Other

- update Cargo.lock dependencies
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).